### PR TITLE
Chore: Update python-nss-ng to v1.0.4 from PyPI

### DIFF
--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -72,9 +72,9 @@ RUN if getent passwd sigul >/dev/null; then \
     echo "sigul ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/sigul && \
     chmod 0440 /etc/sudoers.d/sigul
 
-# Install python-nss-ng from PyPI (Fedora 41 has Python 3.13 which is compatible)
+# Install python-nss-ng v1.0.4 from PyPI (Fedora 41 has Python 3.13 which is compatible)
 ENV INSTALL_SOURCE=pypi
-ENV PYTHON_NSS_NG_VERSION=v0.1.1
+ENV PYTHON_NSS_NG_VERSION=1.0.4
 COPY build-scripts/install-python-nss.sh /tmp/install-python-nss.sh
 RUN chmod +x /tmp/install-python-nss.sh && \
     /tmp/install-python-nss.sh --verify && \

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -35,9 +35,9 @@ COPY patches/ /tmp/patches/
 # Copy local sigul source for debugging builds
 COPY .build-context/sigul /build-context/sigul/
 
-# Install python-nss-ng from PyPI (Fedora 41 has Python 3.13 which is compatible)
+# Install python-nss-ng v1.0.4 from PyPI (Fedora 41 has Python 3.13 which is compatible)
 ENV INSTALL_SOURCE=pypi
-ENV PYTHON_NSS_NG_VERSION=v0.1.1
+ENV PYTHON_NSS_NG_VERSION=1.0.4
 COPY build-scripts/install-python-nss.sh /tmp/install-python-nss.sh
 RUN chmod +x /tmp/install-python-nss.sh && \
     /tmp/install-python-nss.sh --verify && \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -47,9 +47,9 @@ COPY patches/ /tmp/patches/
 # Copy local sigul source for debugging builds
 COPY .build-context/sigul /build-context/sigul/
 
-# Install python-nss-ng from PyPI (Fedora 41 has Python 3.13 which is compatible)
+# Install python-nss-ng v1.0.4 from PyPI (Fedora 41 has Python 3.13 which is compatible)
 ENV INSTALL_SOURCE=pypi
-ENV PYTHON_NSS_NG_VERSION=v0.1.1
+ENV PYTHON_NSS_NG_VERSION=1.0.4
 COPY build-scripts/install-python-nss.sh /tmp/install-python-nss.sh
 RUN chmod +x /tmp/install-python-nss.sh && \
     /tmp/install-python-nss.sh --verify && \


### PR DESCRIPTION
Update all Dockerfiles to use python-nss-ng version 1.0.4 from PyPI. This version includes improved error handling and removes Python 3.9 support.

Changes:
- Update PYTHON_NSS_NG_VERSION from v0.1.1 to 1.0.4 (no 'v' prefix for PyPI)
- Keep INSTALL_SOURCE=pypi for fast, reliable installation
- v1.0.4 includes pre-built wheels for Python 3.10-3.14 on x86_64 and aarch64