### PR TITLE
Fix(deps): Bump pytest to >=9.0.3 for CVE fix

### DIFF
--- a/tests/integration/requirements-minimal.txt
+++ b/tests/integration/requirements-minimal.txt
@@ -16,7 +16,7 @@ psutil>=5.9.0,<6.0.0
 # the integration tests, avoiding complex dependency conflicts.
 
 # Core testing framework
-pytest>=8.4.0,<9.0.0
+pytest>=9.0.3,<10.0.0
 pytest-timeout>=2.3.0,<3.0.0
 
 # HTTP requests for health checks

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -29,7 +29,7 @@ psutil>=5.9.0,<6.0.0
 #   pip install -r tests/integration/requirements.txt
 
 # Core testing framework
-pytest>=8.4.0,<9.0.0
+pytest>=9.0.3,<10.0.0
 pytest-cov>=5.0.0,<7.0.0
 pytest-html>=4.1.0,<5.0.0
 


### PR DESCRIPTION
## Summary

Addresses the security vulnerability flagged by Dependabot in pytest:

> pytest through 9.0.2 on UNIX relies on directories with the `/tmp/pytest-of-{user}` name pattern, which allows local users to cause a denial of service or possibly gain privileges.

## Changes

Bumps pytest to `>=9.0.3,<10.0.0` in both integration test requirement files:

- `tests/integration/requirements.txt`
- `tests/integration/requirements-minimal.txt`

The fix is included in pytest 9.0.3.

## Notes

- Major version bumps from 8.x → 9.x. pytest 9.x requires Python >=3.10, which is satisfied (Dockerfiles use Python 3.13).
- No code changes needed; the integration tests use standard pytest features compatible with 9.x.