### PR TITLE
Chore(deps): Bump python-nss-ng to v1.0.5

### DIFF
--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -72,9 +72,9 @@ RUN if getent passwd sigul >/dev/null; then \
     echo "sigul ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/sigul && \
     chmod 0440 /etc/sudoers.d/sigul
 
-# Install python-nss-ng v1.0.4 from PyPI (Fedora 41 has Python 3.13 which is compatible)
+# Install python-nss-ng v1.0.5 from PyPI (Fedora 41 has Python 3.13 which is compatible)
 ENV INSTALL_SOURCE=pypi
-ENV PYTHON_NSS_NG_VERSION=1.0.4
+ENV PYTHON_NSS_NG_VERSION=1.0.5
 COPY build-scripts/install-python-nss.sh /tmp/install-python-nss.sh
 RUN chmod +x /tmp/install-python-nss.sh && \
     /tmp/install-python-nss.sh --verify && \

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -35,9 +35,9 @@ COPY patches/ /tmp/patches/
 # Copy local sigul source for debugging builds
 COPY .build-context/sigul /build-context/sigul/
 
-# Install python-nss-ng v1.0.4 from PyPI (Fedora 41 has Python 3.13 which is compatible)
+# Install python-nss-ng v1.0.5 from PyPI (Fedora 41 has Python 3.13 which is compatible)
 ENV INSTALL_SOURCE=pypi
-ENV PYTHON_NSS_NG_VERSION=1.0.4
+ENV PYTHON_NSS_NG_VERSION=1.0.5
 COPY build-scripts/install-python-nss.sh /tmp/install-python-nss.sh
 RUN chmod +x /tmp/install-python-nss.sh && \
     /tmp/install-python-nss.sh --verify && \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -47,9 +47,9 @@ COPY patches/ /tmp/patches/
 # Copy local sigul source for debugging builds
 COPY .build-context/sigul /build-context/sigul/
 
-# Install python-nss-ng v1.0.4 from PyPI (Fedora 41 has Python 3.13 which is compatible)
+# Install python-nss-ng v1.0.5 from PyPI (Fedora 41 has Python 3.13 which is compatible)
 ENV INSTALL_SOURCE=pypi
-ENV PYTHON_NSS_NG_VERSION=1.0.4
+ENV PYTHON_NSS_NG_VERSION=1.0.5
 COPY build-scripts/install-python-nss.sh /tmp/install-python-nss.sh
 RUN chmod +x /tmp/install-python-nss.sh && \
     /tmp/install-python-nss.sh --verify && \


### PR DESCRIPTION
## Summary

Updates `PYTHON_NSS_NG_VERSION` in the bridge, client, and server Dockerfiles
from `1.0.4` to `1.0.5` to pick up the [v1.0.5 release](https://github.com/ModeSevenIndustrialSolutions/python-nss-ng/releases/tag/v1.0.5)
(commit `bd6e900e6cbd740e964e7f50a8dea256c18afc5b`).

## Files changed

- `Dockerfile.bridge`
- `Dockerfile.client`
- `Dockerfile.server`

## Notes

- v1.0.5 is published to PyPI (verified), so the existing PyPI-based install
  path (`install-python-nss.sh`) needs no further changes.
- No other references to the `1.0.4` version exist in the repository.