### PR TITLE
CI(workflows): Split release drafter into two workflows

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -1,0 +1,59 @@
+---
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Autolabeler'
+
+# yamllint disable-line rule:truthy
+on:
+  # pull_request is required for autolabeler
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+  # pull_request_target is required for autolabeler on PRs from forks
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions: {}
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ format('al-{0}-pr-{1}', github.event_name, github.event.pull_request.number) }}
+  cancel-in-progress: true
+
+jobs:
+  autolabel:
+    name: 'Autolabel PR'
+    # Run on pull_request_target for forks, or pull_request for same-repo PRs
+    # This prevents duplicate runs for same-repo PRs
+    # yamllint disable rule:line-length
+    if: >
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork) ||
+      (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+    # yamllint enable rule:line-length
+    # SECURITY: pull_request_target with write permissions is safe here because:
+    # 1. This workflow does NOT checkout any code from the PR
+    # 2. The workflow code itself runs from the base branch (not the fork)
+    # 3. release-drafter only makes GitHub API calls (no code execution)
+    # 4. pull_request_target is needed ONLY for autolabeling fork PRs
+    permissions:
+      # write permission is required for autolabeler
+      pull-requests: write
+      # read is sufficient; autolabeler does not create releases
+      contents: read
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: 'audit'
+
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter/autolabeler@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -2,70 +2,34 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 # SPDX-License-Identifier: Apache-2.0
 
-name: 'Release Drafter 🗒️'
+name: 'Release Drafter'
 
 # yamllint disable-line rule:truthy
 on:
   push:
     branches:
       - main
-      - master
-  # pull_request is required for autolabeler
-  pull_request:
-    types:
-      - opened
-      - synchronize
-      - reopened
-  # pull_request_target is required for autolabeler on PRs from forks
-  pull_request_target:
-    types:
-      - opened
-      - synchronize
-      - reopened
 
 permissions: {}
 
 concurrency:
-  # yamllint disable-line rule:line-length
-  group: "rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}"
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  show_concurrency_group:
-    name: 'Concurrency Group'
-    runs-on: 'ubuntu-latest'
-    timeout-minutes: 2
-    steps:
-      - name: 'Concurrency Group'
-        shell: bash
-        # yamllint disable rule:line-length
-        run: |
-          # Concurrency Group
-          echo "Concurrency group: rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}"
-          # shellcheck disable=SC2129
-          echo "## Release Drafter" \
-            >> "$GITHUB_STEP_SUMMARY"
-          echo "Concurrency group: rd-${{ github.event_name }}-${{ github.event.number }}-${{ github.ref }}" \
-            >> "$GITHUB_STEP_SUMMARY"
-
-  # yamllint enable rule:line-length
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
       # write permission is required to create releases
       contents: write
-      # write permission is required for autolabeler
-      pull-requests: write
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+      - uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: 'audit'
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@563bf132657a13ded0b01fcb723c5a58cdd824e2 # v7.2.1
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: release-drafter/release-drafter@5de93583980a40bd78603b6dfdcda5b4df377b32 # v7.2.0


### PR DESCRIPTION
## Summary

Imports the updated release drafter workflows from the
`modeseven-lfreleng-actions/actions-template` repository.

The original single `release-drafter.yaml` workflow has been replaced by two
workflows that run conditionally:

- `.github/workflows/autolabeler.yaml` (new)
- `.github/workflows/release-drafter.yaml` (replaced)

Both files were copied verbatim from the template repo.