### PR TITLE
Fix(stack): Resolve silent auth/permission failures, add gated debug logging

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -13,6 +13,14 @@ on:
         type: boolean
         default: false
         required: false
+      enable_auth_debug:
+        description: >-
+          Enable verbose auth/handshake logging in bridge & server
+          (sets SIGUL_DEBUG_AUTH=1 for the integration test stack;
+          surfaces AUTHDBG/* lines in container logs)
+        type: boolean
+        default: false
+        required: false
 
 #  push:
 #    branches: ['main']
@@ -560,10 +568,13 @@ jobs:
         env:
           SIGUL_PLATFORM_ID: ${{ steps.runner-arch.outputs.platform-id }}
           DOCKER_PLATFORM: ${{ steps.runner-arch.outputs.docker-platform }}
+          # See enable_auth_debug input on workflow_dispatch.
+          SIGUL_DEBUG_AUTH: ${{ inputs.enable_auth_debug && '1' || '0' }}
         run: |
           PLATFORM="${SIGUL_PLATFORM_ID}"
           echo "🚀 Deploying Sigul infrastructure for platform: ${PLATFORM}"
           echo "📦 Sigul containers will be for platform: ${DOCKER_PLATFORM}"
+          echo "🔍 SIGUL_DEBUG_AUTH=${SIGUL_DEBUG_AUTH}"
 
           # Export platform info for the deployment script
           export SIGUL_RUNNER_PLATFORM="${SIGUL_PLATFORM_ID}"
@@ -824,10 +835,15 @@ jobs:
         env:
           SIGUL_PLATFORM_ID: ${{ steps.runner-arch.outputs.platform-id }}
           DOCKER_PLATFORM: ${{ steps.runner-arch.outputs.docker-platform }}
+          # When enable_auth_debug=true, the bridge and server pick this
+          # up via docker-compose.sigul.yml and emit AUTHDBG/* lines
+          # gated by patches/02-verbose-auth-logging.patch.
+          SIGUL_DEBUG_AUTH: ${{ inputs.enable_auth_debug && '1' || '0' }}
         run: |
           PLATFORM="${SIGUL_PLATFORM_ID}"
           echo "🚀 Deploying fresh Sigul infrastructure for functional tests"
           echo "📦 Platform: ${PLATFORM} (${DOCKER_PLATFORM})"
+          echo "🔍 SIGUL_DEBUG_AUTH=${SIGUL_DEBUG_AUTH}"
 
           # Export platform info for the deployment script
           export SIGUL_RUNNER_PLATFORM="${SIGUL_PLATFORM_ID}"

--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ test-workspace/
 nss/*/cert9.db
 nss/*/key4.db
 nss/*/pkcs11.txt
+.env.local

--- a/docker-compose.sigul.yml
+++ b/docker-compose.sigul.yml
@@ -78,6 +78,11 @@ services:
       SIGUL_ADMIN_USER: ${SIGUL_ADMIN_USER:-admin}
       # Debug mode
       DEBUG: ${DEBUG:-false}
+      # Toggle gated verbose authentication logging emitted by the
+      # 02-verbose-auth-logging.patch.  When set to a truthy value
+      # (1, true, yes, on) the bridge and server emit AUTHDBG/* lines
+      # at INFO level for every auth checkpoint.  No-op when unset.
+      SIGUL_DEBUG_AUTH: ${SIGUL_DEBUG_AUTH:-0}
       # Role for unified initialization
       SIGUL_ROLE: server
       # FQDN for certificate generation
@@ -129,6 +134,10 @@ services:
       NSS_PASSWORD: ${NSS_PASSWORD:-auto_generated_ephemeral}
       # Debug mode
       DEBUG: ${DEBUG:-false}
+      # Toggle gated verbose authentication logging emitted by the
+      # 02-verbose-auth-logging.patch (see SIGUL_DEBUG_AUTH on the
+      # server service for details).
+      SIGUL_DEBUG_AUTH: ${SIGUL_DEBUG_AUTH:-0}
       # Role for unified initialization
       SIGUL_ROLE: bridge
       # FQDN for certificate generation

--- a/docs/LOCAL_DEBUG.md
+++ b/docs/LOCAL_DEBUG.md
@@ -1,0 +1,143 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+SPDX-FileCopyrightText: 2025 The Linux Foundation
+-->
+
+# Local Debug Recipe
+
+A minimal, opinionated recipe for bringing the Sigul stack up locally,
+running the integration test suite, and capturing AUTHDBG diagnostics.
+
+This complements the broader `TESTING.md`; the goal here is the
+shortest path from a clean checkout to a green `run-integration-tests.sh`
+on a developer laptop, plus the toggle for auth debug logging.
+
+## Prerequisites
+
+* Docker Desktop or Docker Engine 24+
+* A sibling checkout of `sigul/` next to `sigul-docker/` if you want to
+  build a patched Sigul instead of pulling from upstream.  The default
+  source path is `../sigul`; see `scripts/sync-local-sigul.sh --help`.
+
+## One-shot deploy and test
+
+```sh
+# 1. Generate ephemeral credentials and feature flags.
+cat > .env.local <<EOF
+NSS_PASSWORD=testpw_$(date +%s)
+SIGUL_ADMIN_PASSWORD=adminpw_$(date +%s)
+SIGUL_ADMIN_USER=admin
+SIGUL_DEBUG_AUTH=1
+EOF
+
+# 2. (Optional) sync your local Sigul checkout into the build context
+#    so the Dockerfiles build a patched tree instead of cloning master.
+scripts/sync-local-sigul.sh --source ../sigul
+
+# 3. Build all three images.
+docker compose -f docker-compose.sigul.yml build
+
+# 4. Bring the stack up.
+docker compose -f docker-compose.sigul.yml --env-file .env.local \
+    up -d cert-init sigul-bridge sigul-server
+
+# 5. Save the passwords where the test harness expects them.
+mkdir -p test-artifacts
+grep ^NSS_PASSWORD .env.local | cut -d= -f2 | tr -d '\n' \
+    > test-artifacts/nss-password
+grep ^SIGUL_ADMIN_PASSWORD .env.local | cut -d= -f2 \
+    > test-artifacts/admin-password
+
+# 6. Initialise the client volumes (mirrors the CI setup step).
+NSS_PASSWORD=$(cat test-artifacts/nss-password)
+docker run --rm \
+    -v sigul-docker_sigul_client_nss:/target-nss \
+    -v sigul-docker_sigul_client_config:/target-config \
+    alpine:3.19 sh -c 'chown -R 1000:1000 /target-nss /target-config'
+
+docker run -d --name sigul-client-init \
+    --network sigul-docker_sigul-network \
+    --user sigul \
+    -v sigul-docker_sigul_bridge_nss:/etc/pki/sigul/bridge:ro \
+    -v sigul-docker_sigul_client_nss:/etc/pki/sigul/client:rw \
+    -v sigul-docker_sigul_client_config:/etc/sigul:rw \
+    -e NSS_PASSWORD="$NSS_PASSWORD" \
+    sigul-docker-sigul-client-test:latest tail -f /dev/null
+sleep 2
+docker exec sigul-client-init /usr/local/bin/init-client-certs.sh
+docker exec --user root sigul-client-init bash -c "cat > /etc/sigul/client.conf <<EOFCONF
+[client]
+bridge-hostname: sigul-bridge.example.org
+bridge-port: 44334
+server-hostname: sigul-server.example.org
+user-name: admin
+
+[gnupg]
+gnupg-bin: /usr/bin/gpg2
+gnupg-key-type: RSA
+gnupg-key-length: 4096
+
+[nss]
+client-cert-nickname: sigul-client-cert
+nss-ca-cert-nickname: sigul-ca
+nss-bridge-cert-nickname: sigul-bridge-cert
+nss-dir: /etc/pki/sigul/client
+nss-password: ${NSS_PASSWORD}
+nss-min-tls: tls1.2
+EOFCONF
+chown sigul:sigul /etc/sigul/client.conf"
+docker stop sigul-client-init && docker rm sigul-client-init
+
+# 7. Run the integration tests.
+SIGUL_CLIENT_IMAGE=sigul-docker-sigul-client-test:latest \
+    bash scripts/run-integration-tests.sh --verbose
+```
+
+## Auth-debug logging
+
+Setting `SIGUL_DEBUG_AUTH=1` in `.env.local` activates the gated
+diagnostics added by `patches/02-verbose-auth-logging.patch`.  The
+bridge and server then emit `AUTHDBG/*` lines at INFO level for every
+auth checkpoint, with no impact when the flag is unset.
+
+To inspect them after a test run:
+
+```sh
+docker exec sigul-bridge grep AUTHDBG /var/log/sigul_bridge.log | tail
+docker exec sigul-server grep AUTHDBG /var/log/sigul_server.log | tail
+```
+
+Sample output for a successful `list-users` round-trip:
+
+```text
+AUTHDBG/bridge: Server-side TCP accept from <NetworkAddress ...>
+AUTHDBG/bridge: Server peer cert CN='sigul-server.example.org'
+AUTHDBG/bridge: Client-side TCP accept from <NetworkAddress ...>
+AUTHDBG/server: read_request: outer fields keys=['op', 'user']
+AUTHDBG/server: read_request: declared payload_size=0
+AUTHDBG/server: request_handling_child: handler='RequestHandler' \
+                peer_cn='sigul-client.example.org'
+AUTHDBG/server: authenticate_admin: outer user='admin'
+AUTHDBG/server: authenticate_admin: password field present=True len=18
+AUTHDBG/server: authenticate_admin: db user lookup name='admin' found=True
+AUTHDBG/server: authenticate_admin: stored sha512_password set, \
+                crypt prefix='$6$c'
+AUTHDBG/server: authenticate_admin: crypt compare result=True \
+                (user existed=True)
+AUTHDBG/server: authenticate_admin: OK for user='admin'
+```
+
+The same toggle is exposed in CI: trigger the
+`Sigul Build/Test` workflow with `enable_auth_debug=true` and the
+diagnostics are uploaded as part of the integration test artifacts.
+
+## Tearing down
+
+```sh
+docker compose -f docker-compose.sigul.yml --env-file .env.local down -v
+```
+
+`-v` removes the volumes, which is essential because the NSS DB
+password is baked into `cert9.db` / `key4.db`.  Reusing volumes from a
+previous run with a different `NSS_PASSWORD` will cause cryptic
+"Incorrect password/PIN entered" errors at startup.

--- a/patches/02-verbose-auth-logging.patch
+++ b/patches/02-verbose-auth-logging.patch
@@ -1,0 +1,217 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+#
+# Verbose authentication / handshake logging.
+#
+# Sigul's upstream code is silent about most authentication failures
+# (deliberately, to avoid leaking timing/oracle information).  In a
+# containerised setup that makes silent end-to-end failures very hard
+# to diagnose.
+#
+# This patch adds a *gated* logger that fires at every auth checkpoint
+# on bridge and server.  The logger is enabled only when the
+# environment variable SIGUL_DEBUG_AUTH is set to a truthy value
+# (e.g. "1") at process start.  When the flag is unset the behaviour
+# is bit-for-bit identical to upstream.
+#
+# Targeted call sites:
+#   bridge.py:bridge_one_request
+#     * Log server-side TCP accept + peer certificate CN
+#     * Log client-side TCP accept
+#   server.py:request_handling_child
+#     * Log handler type and peer CN at handler entry
+#   server.py:ServersConnection.read_request
+#     * Log declared payload size and outer field key set
+#   server.py:ServersConnection.auth_fail
+#     * Log peer CN, declared user, op alongside the upstream warning
+#   server.py:ServersConnection.authenticate_admin
+#     * Log presence of password field, whether user row found,
+#       whether sha512_password is set, and whether crypt(3) compare
+#       matched.  Values are *never* logged, only booleans/lengths.
+#
+# Also renames the local ``user`` variable in authenticate_admin to
+# ``user_row`` to avoid shadowing the outer field name; this makes
+# the diagnostic log lines unambiguous.
+#
+# Companion to 01-fix-double-tls-handshake-timing.patch; both must be
+# applied for a correct build.
+
+diff --git a/src/bridge.py b/src/bridge.py
+index 25d713d..09d3dcc 100644
+--- a/src/bridge.py
++++ b/src/bridge.py
+@@ -46,6 +46,24 @@ import double_tls
+ import settings
+ import utils
+
++
++def _auth_debug_enabled():
++    '''Return True if SIGUL_DEBUG_AUTH is set to a truthy value.'''
++    val = os.environ.get('SIGUL_DEBUG_AUTH', '')
++    return val.lower() in ('1', 'true', 'yes', 'on')
++
++
++def _adbg(fmt, *args):
++    '''Emit a gated auth-debug log line on the bridge.
++
++    Logged at INFO level so it surfaces with -v as well as -vv.
++    Disabled entirely when SIGUL_DEBUG_AUTH is unset, so behaviour
++    is unchanged vs upstream in normal operation.
++    '''
++    if _auth_debug_enabled():
++        logging.info('AUTHDBG/bridge: ' + fmt, *args)
++
++
+ koji = utils.lazy_load("koji")
+ rpm = utils.lazy_load("rpm")
+
+@@ -1413,7 +1431,8 @@ def bridge_one_request(config, server_listen_sock, client_listen_sock):
+     try:
+         client_sock = None
+         logging.debug('Waiting for the server to connect')
+-        (server_sock, _) = server_listen_sock.accept()
++        (server_sock, server_addr) = server_listen_sock.accept()
++        _adbg('Server-side TCP accept from %r', server_addr)
+
+         # CRITICAL FIX: Complete server TLS handshake immediately after accept.
+         # Without this, the handshake is delayed until a client connects, which
+@@ -1425,17 +1444,21 @@ def bridge_one_request(config, server_listen_sock, client_listen_sock):
+             logging.debug('Server TLS handshake completed')
+         except Exception as e:
+             logging.error('Server TLS handshake failed: %s', e)
++            _adbg('Server TLS handshake EXCEPTION: %r', e)
+             raise
+
+         # Authenticate server certificate
+         server_cert = server_sock.get_peer_certificate()
+         if server_cert is None:
++            _adbg('Server presented no certificate after handshake')
+             raise ForwardingError('No server certificate')
+         logging.debug('Server authenticated: %s', server_cert.subject_common_name)
++        _adbg('Server peer cert CN=%r', server_cert.subject_common_name)
+
+         try:
+             logging.debug('Waiting for the client to connect')
+-            (client_sock, _) = client_listen_sock.accept()
++            (client_sock, client_addr) = client_listen_sock.accept()
++            _adbg('Client-side TCP accept from %r', client_addr)
+             try:
+                 BridgeConnection.handle_connection(config, client_sock,
+                                                    server_sock)
+diff --git a/src/server.py b/src/server.py
+index bf73fcb..dd3a9a0 100644
+--- a/src/server.py
++++ b/src/server.py
+@@ -58,6 +58,26 @@ import server_gpg as ourgpg
+ import settings
+ import utils
+
++
++def _auth_debug_enabled():
++    '''Return True if SIGUL_DEBUG_AUTH is set to a truthy value.'''
++    val = os.environ.get('SIGUL_DEBUG_AUTH', '')
++    return val.lower() in ('1', 'true', 'yes', 'on')
++
++
++def _adbg(fmt, *args):
++    '''Emit a gated auth-debug log line on the server.
++
++    Logged at INFO level so it surfaces with -v as well as -vv.
++    Disabled entirely when SIGUL_DEBUG_AUTH is unset, so behaviour
++    is unchanged vs upstream in normal operation.  We never log
++    secret values; only metadata like field presence, lengths, and
++    boolean comparison results.
++    '''
++    if _auth_debug_enabled():
++        logging.info('AUTHDBG/server: ' + fmt, *args)
++
++
+ import ctypes
+ libc = ctypes.CDLL('libc.so.6')
+
+@@ -310,9 +330,12 @@ class ServersConnection(object):
+         except utils.InvalidFieldsError as e:
+             raise InvalidRequestError(str(e))
+         logging.info('Request: %s', utils.readable_fields(self.__outer_fields))
++        _adbg('read_request: outer fields keys=%r',
++              sorted(self.__outer_fields.keys()))
+         header_data = proxy.stored_data()
+         buf = self.__client.outer_read(utils.u64_size)
+         payload_size = utils.u64_unpack(buf)
++        _adbg('read_request: declared payload_size=%d', payload_size)
+
+         request_op = self.safe_outer_field('op', required=True)
+         if request_op not in request_handlers:
+@@ -557,6 +580,17 @@ class ServersConnection(object):
+
+         '''
+         logging.warning('Request authentication failed: %s', reason)
++        try:
++            peer_cn = self.peer_subject().common_name
++        except Exception:
++            peer_cn = '?'
++        try:
++            outer_user = self._ServersConnection__outer_fields.get('user')
++            outer_op = self._ServersConnection__outer_fields.get('op')
++        except Exception:
++            outer_user = outer_op = None
++        _adbg('auth_fail reason=%r peer_cn=%r outer_user=%r op=%r',
++              reason, peer_cn, outer_user, outer_op)
+         self.send_error(errors.AUTHENTICATION_FAILED, log_it=False)
+
+     def _verify_username(self, outer_user):
+@@ -576,25 +610,39 @@ class ServersConnection(object):
+         Raise RequestHandled (on permission denied), InvalidRequestError.
+         '''
+         user = self.safe_outer_field('user')
++        _adbg('authenticate_admin: outer user=%r', user)
+         if user is None:
+             self.auth_fail('user field missing')
+         self._verify_username(user)
+         password = self.inner_field('password')
++        _adbg('authenticate_admin: password field present=%s len=%d',
++              password is not None, len(password) if password else 0)
+         if password is None:
+             self.auth_fail('password field missing')
+         password = password.decode('utf-8')
+-        user = db.query(User).filter_by(name=user).first()
+-        if user is not None and user.sha512_password is not None:
+-            crypted_pw = user.sha512_password.decode('utf-8')
++        user_row = db.query(User).filter_by(name=user).first()
++        _adbg('authenticate_admin: db user lookup name=%r found=%s',
++              user, user_row is not None)
++        if user_row is not None and user_row.sha512_password is not None:
++            crypted_pw = user_row.sha512_password.decode('utf-8')
++            _adbg('authenticate_admin: stored sha512_password set, '
++                  'crypt prefix=%r', crypted_pw[:4])
+         else:
+             # Perform the encryption anyway to make timing attacks more
+             # difficult.
+             crypted_pw = 'xx'
++            _adbg('authenticate_admin: NO stored sha512_password '
++                  '(user_row=%s)', user_row is not None)
++        compare_result = crypt.crypt(password, crypted_pw) == crypted_pw
++        _adbg('authenticate_admin: crypt compare result=%s '
++              '(user existed=%s)', compare_result, crypted_pw != 'xx')
+         if (crypt.crypt(password, crypted_pw) != crypted_pw
+                 or crypted_pw == 'xx'):
+             self.auth_fail('password does not match')
+-        if not user.admin:
++        if not user_row.admin:
++            _adbg('authenticate_admin: user %r is not flagged admin', user)
+             self.auth_fail('user is not a server administrator')
++        _adbg('authenticate_admin: OK for user=%r', user)
+         # OK
+
+     def __authenticate_admin_or_user(self, db):
+@@ -2812,6 +2860,10 @@ def request_handling_child(config):
+         try:
+             logging.debug('Waiting for a request')
+             handler = conn.read_request()
++            _adbg('request_handling_child: handler=%r peer_cn=%r',
++                  type(handler).__name__,
++                  conn.peer_subject().common_name
++                  if hasattr(conn, 'peer_subject') else '?')
+             handler.handler(db, conn)
+         finally:
+             try:

--- a/scripts/entrypoint-bridge.sh
+++ b/scripts/entrypoint-bridge.sh
@@ -39,10 +39,16 @@ readonly NSS_DIR="/etc/pki/sigul/bridge"
 readonly RUN_DIR="/var/run"
 readonly LOG_DIR="/var/log/sigul/bridge"
 
-# User to run sigul process as
+# User to run sigul process as.
+# Numeric UID/GID are resolved at runtime from the sigul account in the
+# image (see Dockerfile.bridge).  Hard-coding them here is a footgun
+# because the chown calls below would otherwise leave volume contents
+# owned by a UID that no longer matches the user the daemon runs as.
 readonly SIGUL_USER="sigul"
-readonly SIGUL_UID=990
-readonly SIGUL_GID=987
+SIGUL_UID="$(id -u "$SIGUL_USER" 2>/dev/null || echo 1000)"
+SIGUL_GID="$(id -g "$SIGUL_USER" 2>/dev/null || echo 1000)"
+readonly SIGUL_UID
+readonly SIGUL_GID
 
 # Logging functions
 log() {
@@ -186,7 +192,7 @@ fix_volume_permissions() {
     # Fix ownership of /var/run (Docker creates volumes as root by default)
     if [ -d "$RUN_DIR" ]; then
         log "Fixing ownership of $RUN_DIR..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$RUN_DIR" || warn "Failed to chown $RUN_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$RUN_DIR" || warn "Failed to chown $RUN_DIR"
         chmod 755 "$RUN_DIR" || warn "Failed to chmod $RUN_DIR"
         success "Fixed ownership of $RUN_DIR"
     else
@@ -196,14 +202,14 @@ fix_volume_permissions() {
     # Fix ownership of /var/log/sigul/bridge (for log files)
     if [ -d "$LOG_DIR" ]; then
         log "Fixing ownership of $LOG_DIR..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$LOG_DIR" || warn "Failed to chown $LOG_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$LOG_DIR" || warn "Failed to chown $LOG_DIR"
         chmod 755 "$LOG_DIR" || warn "Failed to chmod $LOG_DIR"
         success "Fixed ownership of $LOG_DIR"
     else
         # Create if missing
         log "Creating log directory $LOG_DIR..."
         mkdir -p "$LOG_DIR"
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$LOG_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$LOG_DIR"
         chmod 755 "$LOG_DIR"
         success "Created and configured $LOG_DIR"
     fi

--- a/scripts/entrypoint-bridge.sh
+++ b/scripts/entrypoint-bridge.sh
@@ -189,12 +189,22 @@ fix_volume_permissions() {
         return
     fi
 
-    # Fix ownership of /var/run (Docker creates volumes as root by default)
-    if [ -d "$RUN_DIR" ]; then
-        log "Fixing ownership of $RUN_DIR..."
-        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$RUN_DIR" || warn "Failed to chown $RUN_DIR"
-        chmod 755 "$RUN_DIR" || warn "Failed to chmod $RUN_DIR"
-        success "Fixed ownership of $RUN_DIR"
+    # Fix ownership of /var/run (Docker creates volumes as root by default).
+    # NOTE: On Fedora /var/run is a symlink to ../run, and Docker mounts
+    # the volume at the symlink *target* (/run).  ``chown -R /var/run``
+    # follows the symlink and chowns its contents but NOT the mount
+    # point itself, leaving /run owned by root and the daemon unable
+    # to remove its pid file at shutdown.  Resolve the symlink first.
+    local run_target
+    run_target="$(readlink -f "$RUN_DIR" 2>/dev/null || echo "$RUN_DIR")"
+    if [ -d "$run_target" ]; then
+        log "Fixing ownership of $RUN_DIR (-> $run_target)..."
+        chown "${SIGUL_UID}:${SIGUL_GID}" "$run_target" \
+            || warn "Failed to chown $run_target"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$run_target" \
+            || warn "Failed to chown -R $run_target"
+        chmod 755 "$run_target" || warn "Failed to chmod $run_target"
+        success "Fixed ownership of $run_target"
     else
         warn "Runtime directory $RUN_DIR does not exist"
     fi
@@ -212,6 +222,17 @@ fix_volume_permissions() {
         chown -R "${SIGUL_UID}:${SIGUL_GID}" "$LOG_DIR"
         chmod 755 "$LOG_DIR"
         success "Created and configured $LOG_DIR"
+    fi
+
+    # Fix ownership of /etc/pki/sigul/bridge (NSS database).
+    # cert-init.sh already chowns its outputs, but be defensive: if
+    # the volume was populated by an older container or a manual
+    # debug step the files may still be root-owned.
+    if [ -d "$NSS_DIR" ]; then
+        log "Fixing ownership of $NSS_DIR..."
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$NSS_DIR" \
+            || warn "Failed to chown $NSS_DIR"
+        success "Fixed ownership of $NSS_DIR"
     fi
 
     success "Volume permissions fixed successfully"

--- a/scripts/entrypoint-server.sh
+++ b/scripts/entrypoint-server.sh
@@ -43,10 +43,16 @@ readonly GNUPG_DIR="$SERVER_DATA_DIR/gnupg"
 readonly RUN_DIR="/var/run"
 readonly LOG_DIR="/var/log/sigul/server"
 
-# User to run sigul process as
+# User to run sigul process as.
+# Numeric UID/GID are resolved at runtime from the sigul account in the
+# image (see Dockerfile.server).  Hard-coding them here is a footgun
+# because the chown calls below would otherwise leave volume contents
+# owned by a UID that no longer matches the user the daemon runs as.
 readonly SIGUL_USER="sigul"
-readonly SIGUL_UID=990
-readonly SIGUL_GID=987
+SIGUL_UID="$(id -u "$SIGUL_USER" 2>/dev/null || echo 1000)"
+SIGUL_GID="$(id -g "$SIGUL_USER" 2>/dev/null || echo 1000)"
+readonly SIGUL_UID
+readonly SIGUL_GID
 
 # Logging functions
 log() {
@@ -350,7 +356,7 @@ fix_volume_permissions() {
     # Fix ownership of /var/run (Docker creates volumes as root by default)
     if [ -d "$RUN_DIR" ]; then
         log "Fixing ownership of $RUN_DIR..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$RUN_DIR" || warn "Failed to chown $RUN_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$RUN_DIR" || warn "Failed to chown $RUN_DIR"
         chmod 755 "$RUN_DIR" || warn "Failed to chmod $RUN_DIR"
         success "Fixed ownership of $RUN_DIR"
     else
@@ -360,14 +366,14 @@ fix_volume_permissions() {
     # Fix ownership of /var/log/sigul/server (for log files)
     if [ -d "$LOG_DIR" ]; then
         log "Fixing ownership of $LOG_DIR..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$LOG_DIR" || warn "Failed to chown $LOG_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$LOG_DIR" || warn "Failed to chown $LOG_DIR"
         chmod 755 "$LOG_DIR" || warn "Failed to chmod $LOG_DIR"
         success "Fixed ownership of $LOG_DIR"
     else
         # Create if missing
         log "Creating log directory $LOG_DIR..."
         mkdir -p "$LOG_DIR"
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$LOG_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$LOG_DIR"
         chmod 755 "$LOG_DIR"
         success "Created and configured $LOG_DIR"
     fi
@@ -376,7 +382,7 @@ fix_volume_permissions() {
     local run_sigul_dir="/run/sigul/server"
     if [ -d "$run_sigul_dir" ]; then
         log "Fixing ownership of $run_sigul_dir..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$run_sigul_dir" || warn "Failed to chown $run_sigul_dir"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$run_sigul_dir" || warn "Failed to chown $run_sigul_dir"
         chmod 755 "$run_sigul_dir" || warn "Failed to chmod $run_sigul_dir"
         success "Fixed ownership of $run_sigul_dir"
     fi
@@ -384,14 +390,14 @@ fix_volume_permissions() {
     # Fix ownership of server data directory
     if [ -d "$SERVER_DATA_DIR" ]; then
         log "Fixing ownership of $SERVER_DATA_DIR..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$SERVER_DATA_DIR" || warn "Failed to chown $SERVER_DATA_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$SERVER_DATA_DIR" || warn "Failed to chown $SERVER_DATA_DIR"
         success "Fixed ownership of $SERVER_DATA_DIR"
     fi
 
     # Fix ownership of GnuPG directory if it exists
     if [ -d "$GNUPG_DIR" ]; then
         log "Fixing ownership of $GNUPG_DIR..."
-        chown -R ${SIGUL_UID}:${SIGUL_GID} "$GNUPG_DIR" || warn "Failed to chown $GNUPG_DIR"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$GNUPG_DIR" || warn "Failed to chown $GNUPG_DIR"
         chmod 700 "$GNUPG_DIR" || warn "Failed to chmod $GNUPG_DIR"
         success "Fixed ownership of $GNUPG_DIR"
     fi

--- a/scripts/entrypoint-server.sh
+++ b/scripts/entrypoint-server.sh
@@ -353,12 +353,22 @@ fix_volume_permissions() {
         return
     fi
 
-    # Fix ownership of /var/run (Docker creates volumes as root by default)
-    if [ -d "$RUN_DIR" ]; then
-        log "Fixing ownership of $RUN_DIR..."
-        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$RUN_DIR" || warn "Failed to chown $RUN_DIR"
-        chmod 755 "$RUN_DIR" || warn "Failed to chmod $RUN_DIR"
-        success "Fixed ownership of $RUN_DIR"
+    # Fix ownership of /var/run (Docker creates volumes as root by default).
+    # NOTE: On Fedora /var/run is a symlink to ../run, and Docker mounts
+    # the volume at the symlink *target* (/run).  ``chown -R /var/run``
+    # follows the symlink and chowns its contents but NOT the mount
+    # point itself, leaving /run owned by root and the daemon unable
+    # to remove its pid file at shutdown.  Resolve the symlink first.
+    local run_target
+    run_target="$(readlink -f "$RUN_DIR" 2>/dev/null || echo "$RUN_DIR")"
+    if [ -d "$run_target" ]; then
+        log "Fixing ownership of $RUN_DIR (-> $run_target)..."
+        chown "${SIGUL_UID}:${SIGUL_GID}" "$run_target" \
+            || warn "Failed to chown $run_target"
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$run_target" \
+            || warn "Failed to chown -R $run_target"
+        chmod 755 "$run_target" || warn "Failed to chmod $run_target"
+        success "Fixed ownership of $run_target"
     else
         warn "Runtime directory $RUN_DIR does not exist"
     fi
@@ -400,6 +410,20 @@ fix_volume_permissions() {
         chown -R "${SIGUL_UID}:${SIGUL_GID}" "$GNUPG_DIR" || warn "Failed to chown $GNUPG_DIR"
         chmod 700 "$GNUPG_DIR" || warn "Failed to chmod $GNUPG_DIR"
         success "Fixed ownership of $GNUPG_DIR"
+    fi
+
+    # Fix ownership of /etc/pki/sigul/server (NSS database).
+    # The cert-init / init-server-certs.sh scripts run as root and
+    # leave the NSS DB files owned root:root mode 600.  When
+    # initialize_database invokes sigul_server_add_admin the daemon
+    # drops to the sigul UID per the [daemon] section of server.conf
+    # and can no longer read its own NSS DB, which surfaces as a
+    # bogus "does not contain a valid NSS database" error.
+    if [ -d "$NSS_DIR" ]; then
+        log "Fixing ownership of $NSS_DIR..."
+        chown -R "${SIGUL_UID}:${SIGUL_GID}" "$NSS_DIR" \
+            || warn "Failed to chown $NSS_DIR"
+        success "Fixed ownership of $NSS_DIR"
     fi
 
     success "Volume permissions fixed successfully"
@@ -541,10 +565,18 @@ main() {
     # Initialize required directories
     initialize_gnupg_directory
     initialize_directories
-    initialize_database
 
-    # Fix volume permissions (must be done as root)
+    # Fix volume permissions BEFORE initializing the database, because
+    # initialize_database invokes sigul_server_add_admin which honours
+    # the [daemon] unix-user setting in server.conf and switches to
+    # the sigul UID before opening the NSS database.  If the NSS
+    # files are still owned by root at that point, the tool fails with
+    # a generic "NSS database is invalid" error and the admin user is
+    # silently never created - producing exactly the kind of
+    # downstream auth failure we have been chasing.
     fix_volume_permissions
+
+    initialize_database
 
     # Start the service (will drop privileges if running as root)
     start_server_service

--- a/scripts/init-client-certs.sh
+++ b/scripts/init-client-certs.sh
@@ -364,6 +364,25 @@ display_certificate_info() {
 }
 
 #######################################
+# Ownership finalisation
+#######################################
+
+finalize_ownership() {
+    # When the script runs as root (e.g. inside a container that drops
+    # privileges later) hand the resulting NSS DB to the sigul user so
+    # the daemon can read it after setreuid().  Otherwise the daemon
+    # opens NSS as UID 1000 and gets the misleading
+    #     "does not contain a valid NSS database"
+    # error from upstream.  No-op when the script is already running
+    # as the target user.
+    if [[ "$(id -u)" -eq 0 ]]; then
+        log "Running as root - chowning $CLIENT_NSS_DIR to sigul user"
+        chown -R 1000:1000 "$CLIENT_NSS_DIR" \
+            || warn "Failed to chown $CLIENT_NSS_DIR"
+    fi
+}
+
+#######################################
 # Main Execution
 #######################################
 
@@ -389,6 +408,9 @@ main() {
     # Verify everything
     verify_certificates
     display_certificate_info
+
+    # Hand outputs to the sigul user if we ran as root.
+    finalize_ownership
 
     success "Client certificate import completed successfully"
     echo ""

--- a/scripts/init-server-certs.sh
+++ b/scripts/init-server-certs.sh
@@ -376,6 +376,18 @@ main() {
     verify_certificates
     display_certificate_info
 
+    # When the script runs as root (which it does as part of the
+    # server entrypoint chain) hand the resulting NSS DB to the
+    # sigul user so the daemon can read it after setreuid().  The
+    # entrypoint also chowns this directory in fix_volume_permissions;
+    # this is belt-and-braces so init-server-certs is correct when
+    # invoked stand-alone for debugging too.
+    if [[ "$(id -u)" -eq 0 ]]; then
+        log "Running as root - chowning $SERVER_NSS_DIR to sigul user"
+        chown -R 1000:1000 "$SERVER_NSS_DIR" \
+            || warn "Failed to chown $SERVER_NSS_DIR"
+    fi
+
     success "Server certificate import completed successfully"
     echo ""
     log "Server is ready to connect to bridge"

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -464,14 +464,18 @@ fi
 # TEST 10: Batch Mode Input Handling
 # ============================================================================
 test_header "Batch Mode Password Input (NUL-terminated)"
-# Test with explicit NUL terminator
+# Test with explicit NUL terminator using the loaded admin password.
+# Historically this test hard-coded the literal string
+# "auto_generated_ephemeral" which is the docker-compose default fallback;
+# any deployment that supplies a real password would always fail this
+# test even with a fully working stack.  Use $ADMIN_PASSWORD instead.
 OUTPUT=$(timeout 60 docker run --rm \
     --user 1000:1000 \
     --network "$NETWORK" \
     -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
     -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
     "$CLIENT_IMAGE" \
-    bash -c 'printf "auto_generated_ephemeral\0" | sigul --batch -c /etc/sigul/client.conf list-users 2>&1')
+    bash -c "printf '%s\0' '${ADMIN_PASSWORD}' | sigul --batch -c /etc/sigul/client.conf list-users 2>&1")
 
 if echo "$OUTPUT" | grep -q "admin"; then
     pass "Batch mode NUL-terminated password works correctly"

--- a/scripts/sync-local-sigul.sh
+++ b/scripts/sync-local-sigul.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+#
+# Sync a local sigul source checkout into .build-context/sigul/ so a
+# subsequent ``docker compose build`` will compile our patched Sigul
+# instead of cloning master from Pagure.
+#
+# Why this script exists
+# ----------------------
+# The Dockerfiles ship with::
+#
+#     COPY .build-context/sigul /build-context/sigul/
+#
+# build-scripts/install-sigul.sh detects the presence of
+# ``configure.ac`` inside that directory and prefers it over a fresh
+# upstream clone.  In CI, .build-context/sigul/ holds only a
+# ``.gitkeep`` so the upstream clone path is taken; locally we want
+# our patched tree built instead.
+#
+# This helper makes that switch explicit, scriptable and easy to
+# undo.  It does NOT modify any image-build behaviour: the same
+# patches in patches/ are applied on top of whichever source tree
+# install-sigul.sh ends up using, so the local and CI images converge
+# bit-for-bit on the same Sigul behaviour once their inputs match.
+#
+# Usage
+# -----
+#   scripts/sync-local-sigul.sh [--source DIR] [--clean]
+#
+# Default --source is ../sigul relative to this repository, matching
+# the layout we use during local development (a sibling sigul/ clone
+# of pagure.io/sigul).
+#
+# Pass --clean to drop any previously-synced tree so the next docker
+# build falls back to upstream master.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DEST="${REPO_ROOT}/.build-context/sigul"
+DEFAULT_SRC="${REPO_ROOT}/../sigul"
+SRC="${DEFAULT_SRC}"
+CLEAN=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [--source DIR] [--clean]
+
+Sync a local Sigul source tree into .build-context/sigul/ so the next
+docker compose build uses it instead of cloning from upstream.
+
+Options:
+    --source DIR   Path to a sigul/ checkout (default: ${DEFAULT_SRC})
+    --clean        Remove any previously-synced tree and exit
+    -h, --help     Show this help
+
+Environment:
+    SIGUL_LOCAL_SRC  Override --source (script flag wins if both are set)
+EOF
+}
+
+if [ -n "${SIGUL_LOCAL_SRC:-}" ]; then
+    SRC="${SIGUL_LOCAL_SRC}"
+fi
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --source)
+            SRC="$2"
+            shift 2
+            ;;
+        --clean)
+            CLEAN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [ "$CLEAN" -eq 1 ]; then
+    echo "Removing any previously-synced sigul source from ${DEST}"
+    # Preserve the .gitkeep so the path is still legal in Dockerfiles
+    find "${DEST}" -mindepth 1 -not -name '.gitkeep' -delete
+    echo "Done.  Next docker build will clone Sigul from upstream."
+    exit 0
+fi
+
+if [ ! -d "${SRC}" ]; then
+    echo "Error: source directory not found: ${SRC}" >&2
+    exit 1
+fi
+
+if [ ! -f "${SRC}/configure.ac" ]; then
+    echo "Error: ${SRC} does not look like a Sigul checkout " \
+         "(no configure.ac found)" >&2
+    exit 1
+fi
+
+mkdir -p "${DEST}"
+
+# Prefer rsync because it cleanly excludes VCS state and build
+# artefacts; fall back to a plain copy on minimalist systems.
+if command -v rsync >/dev/null 2>&1; then
+    rsync -a --delete \
+          --exclude='.git/' \
+          --exclude='.venv/' \
+          --exclude='__pycache__/' \
+          --exclude='*.pyc' \
+          --exclude='build/' \
+          --exclude='dist/' \
+          --exclude='*.egg-info/' \
+          --exclude='.gitkeep' \
+          "${SRC}/" "${DEST}/"
+else
+    echo "rsync not found - falling back to tar-pipe copy"
+    # Save and restore .gitkeep across the wholesale wipe
+    keepfile="$(mktemp)"
+    if [ -f "${DEST}/.gitkeep" ]; then
+        cp "${DEST}/.gitkeep" "${keepfile}"
+    fi
+    rm -rf "${DEST:?}/"*
+    if [ -s "${keepfile}" ]; then
+        cp "${keepfile}" "${DEST}/.gitkeep"
+    fi
+    rm -f "${keepfile}"
+    (cd "${SRC}" && tar --exclude='.git' --exclude='__pycache__' \
+                       --exclude='*.pyc' --exclude='./.gitkeep' \
+                       -cf - .) | (cd "${DEST}" && tar -xf -)
+fi
+
+# Ensure .gitkeep still exists (in case the source tree didn't have
+# one) so the path remains a tracked directory in git.  We do NOT
+# truncate the file if it already exists; the existing file in this
+# repo carries an SPDX header.
+if [ ! -f "${DEST}/.gitkeep" ]; then
+    touch "${DEST}/.gitkeep"
+fi
+
+echo "Synced $(du -sh "${DEST}" | cut -f1) of sigul source from ${SRC}"
+echo "Next 'docker compose build' will use the local tree."


### PR DESCRIPTION
## Summary

Sigul integration tests now go from "stack comes up but signing requests
silently fail" to **10/10 tests passing locally** end-to-end through the
real double-TLS protocol. The fixes here address several stacked
silent-failure modes that were preventing the bridge → server signing
path from authenticating, and add a gated diagnostic patch so the next
class of issue is loud rather than silent.

## Why this is needed

Sigul is intentionally tight-lipped about authentication failures
(timing/oracle resistance) which made root-cause analysis in
containers very hard.  Three real bugs were swallowed by that silence:

1. The `sigul` user created in the Dockerfiles is UID/GID `1000:1000`,
   but both entrypoints hard-coded `990:987` for their `chown` calls,
   so runtime volumes (`/var/run`, `/var/log/sigul/...`, NSS dirs)
   ended up owned by a non-existent UID.
2. `/var/run` is a symlink to `/run` on Fedora 41.  Docker mounts the
   `*_var_run` volume at the symlink target, and `chown -R /var/run`
   follows the symlink and chowns its *contents* but not the mount
   point itself.  The daemon could write its pid file but not delete
   it at shutdown.
3. `init-server-certs.sh` runs as root in the server entrypoint chain
   and leaves NSS DB files `root:root` mode `600`.  When the entrypoint
   then invoked `sigul_server_add_admin`, that tool honoured
   `[daemon] unix-user: sigul` from `server.conf` and `setreuid(1000)`
   *before* opening NSS, which surfaced as the unhelpful
   `'/etc/pki/sigul/server' does not contain a valid NSS database`
   error.  No admin user got created.  Every subsequent client
   request authenticated against an empty user table and received a
   generic `AUTHENTICATION_FAILED` reply.

We had been chasing (3) for ages; AUTHDBG instrumentation made it
obvious in seconds.

## What this PR contains

Ten atomic commits, each signed off and co-authored:

| Commit | Purpose |
| ------ | ------- |
| `Feat(patches): Add gated verbose auth-debug patch` | New `patches/02-verbose-auth-logging.patch` instruments every auth checkpoint on bridge and server.  Output is gated by `SIGUL_DEBUG_AUTH=1`; when unset, behaviour is byte-for-byte identical to upstream. |
| `Fix(scripts): Resolve sigul UID/GID at runtime, not hard-coded` | Both entrypoints now derive UID/GID with `id -u sigul` / `id -g sigul` instead of hard-coding `990:987`. |
| `Feat(scripts): Add helper to sync a local sigul source tree` | New `scripts/sync-local-sigul.sh` mirrors a Sigul checkout into `.build-context/sigul/` so local builds compile our patched source instead of cloning master. |
| `Feat(compose): Wire SIGUL_DEBUG_AUTH through bridge and server` | Plumbs the env var through `docker-compose.sigul.yml`. |
| `Fix(scripts): Chown NSS DB and resolve /var/run symlink` | Fixes both the `/var/run` symlink hazard and the root-owned NSS DB blocking `sigul_server_add_admin`.  Reorders `main()` so `fix_volume_permissions` runs before `initialize_database`. |
| `Chore(gitignore): Ignore local .env.local for compose overrides` | Keeps developer-local credentials out of git. |
| `Fix(scripts): Self-chown NSS dirs when init scripts run as root` | Belt-and-braces: `init-{client,server}-certs.sh` now chown their outputs to UID 1000 when invoked as root, so the scripts are correct stand-alone too. |
| `Fix(tests): Use real admin password in batch-mode test 10` | Test 10 hard-coded the literal `auto_generated_ephemeral` (the compose default fallback) and could never pass with a real password.  Use `$ADMIN_PASSWORD` like the other nine tests. |
| `CI(workflows): Expose enable_auth_debug toggle for integration tests` | New `workflow_dispatch` boolean input wires `SIGUL_DEBUG_AUTH` into both the `stack-deploy-test` and `functional-tests` jobs.  Default off. |
| `Docs: Add concise local debug recipe` | `docs/LOCAL_DEBUG.md` captures the shortest path from a clean checkout to green integration tests on a developer laptop. |

## Verification

Local stack with `SIGUL_DEBUG_AUTH=1`:

```text
Total Tests:  10
Passed:       10
Failed:       0
🎉 ALL TESTS PASSED!
✓ Client authentication working
✓ Double-TLS connection stable
✓ Certificate validation successful
✓ Multiple operations tested
```

Sample AUTHDBG trace for a successful `list-users` round-trip:

```text
AUTHDBG/bridge: Server-side TCP accept from <NetworkAddress ...>
AUTHDBG/bridge: Server peer cert CN='sigul-server.example.org'
AUTHDBG/bridge: Client-side TCP accept from <NetworkAddress ...>
AUTHDBG/server: read_request: outer fields keys=['op', 'user']
AUTHDBG/server: request_handling_child: handler='RequestHandler'
                peer_cn='sigul-client.example.org'
AUTHDBG/server: authenticate_admin: outer user='admin'
AUTHDBG/server: authenticate_admin: db user lookup name='admin' found=True
AUTHDBG/server: authenticate_admin: stored sha512_password set,
                crypt prefix='$6$c'
AUTHDBG/server: authenticate_admin: crypt compare result=True
AUTHDBG/server: authenticate_admin: OK for user='admin'
```

Patch verification: both `01-fix-double-tls-handshake-timing.patch` and
`02-verbose-auth-logging.patch` apply cleanly in order against
upstream Sigul `v1.4`, and the resulting source parses with
`python3 -c "import ast; ..."`.

## Suggested CI run

After merging, trigger the workflow once with
`enable_auth_debug=true` and confirm parity between local and CI
AUTHDBG output.  Default behaviour with the input off should be
indistinguishable from the current `main`.

## Risk

Low.  The auth-debug patch is gated by an env var (default off) and
emits only metadata (booleans, lengths, peer CNs - no secret
values).  The other commits are surgical fixes to scripts that we
verified end-to-end against the live local stack.