### PR TITLE
Fix(stack): Capture daemon logs, harden crypt shim, set user-name

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -1027,6 +1027,12 @@ jobs:
           bridge-hostname: sigul-bridge.example.org
           bridge-port: 44334
           server-hostname: sigul-server.example.org
+          # Default identity for batch-mode requests.  Without this,
+          # sigul falls back to getpass.getuser() inside the client
+          # container - that resolves to the sigul user, which is not
+          # the admin user we created in the server database, so
+          # every request would fail AUTHENTICATION_FAILED.
+          user-name: admin
 
           [gnupg]
           gnupg-bin: /usr/bin/gpg2

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -649,6 +649,18 @@ jobs:
                 "diagnostics/${container}.log" 2>&1 || true
               docker inspect "${container}" > \
                 "diagnostics/${container}.inspect.json" 2>/dev/null || true
+
+              # Capture Sigul's own log file too.  Sigul writes to
+              # /var/log/sigul_<role>.log via setup_logging() and that
+              # path is NOT on a persisted volume, so 'docker logs'
+              # only shows the entrypoint output.  docker cp works
+              # against stopped containers as well as running ones.
+              role="${container#sigul-}"  # 'server' or 'bridge'
+              docker cp \
+                "${container}:/var/log/sigul_${role}.log" \
+                "diagnostics/${container}.sigul.log" 2>/dev/null \
+                || echo "(no /var/log/sigul_${role}.log in ${container})" \
+                   > "diagnostics/${container}.sigul.log"
             else
               echo "Container not found: ${container}"
             fi
@@ -1060,6 +1072,39 @@ jobs:
           echo 'Running Sigul integration tests against fresh infrastructure...'
           chmod +x scripts/run-integration-tests.sh
           ./scripts/run-integration-tests.sh --verbose
+
+      - name: 'Capture Sigul daemon logs and container diagnostics'
+        if: always()
+        shell: bash
+        run: |
+          # Sigul writes its real log to /var/log/sigul_<role>.log
+          # *inside* the container - that path is not on a persisted
+          # volume, so 'docker logs' only shows the entrypoint output
+          # and AUTHDBG/* lines disappear when the container exits.
+          # docker cp works against running and stopped containers,
+          # so capture the daemon log files into test-artifacts/.
+          mkdir -p test-artifacts/sigul-logs
+          for container in sigul-server sigul-bridge; do
+            if docker ps -a --format '{{.Names}}' \
+                | grep -q "^${container}$"; then
+              role="${container#sigul-}"  # 'server' or 'bridge'
+              echo "Collecting /var/log/sigul_${role}.log from ${container}"
+              docker cp \
+                "${container}:/var/log/sigul_${role}.log" \
+                "test-artifacts/sigul-logs/${container}.sigul.log" \
+                2>/dev/null \
+                || echo "(no /var/log/sigul_${role}.log)" \
+                   > "test-artifacts/sigul-logs/${container}.sigul.log"
+              docker logs "${container}" \
+                > "test-artifacts/sigul-logs/${container}.docker.log" \
+                2>&1 || true
+              docker inspect "${container}" \
+                > "test-artifacts/sigul-logs/${container}.inspect.json" \
+                2>/dev/null || true
+            fi
+          done
+          echo "Captured Sigul daemon logs:"
+          ls -la test-artifacts/sigul-logs/ || true
 
       - name: 'Upload integration test artifacts'
         # yamllint disable-line rule:line-length

--- a/build-scripts/crypt_compat.py
+++ b/build-scripts/crypt_compat.py
@@ -30,29 +30,44 @@ if sys.version_info >= (3, 13):
 
         Args:
             word: The password to hash (str or bytes)
-            salt: The salt string (must start with $6$ for SHA-512)
+            salt: The salt string.  Real callers will pass an
+                  ``$6$...`` SHA-512 crypt salt; legacy code may
+                  also pass a non-crypt placeholder (Sigul, for
+                  example, intentionally calls ``crypt('xx')`` as a
+                  timing-attack guard when the user does not exist).
 
         Returns:
-            The hashed password string in crypt format
-
-        Raises:
-            ValueError: If salt format is not supported
+            The hashed password string in crypt format, or - for
+            placeholder/invalid salts - a deterministic non-crypt
+            string that will never equal a real crypt result and
+            will never equal the salt itself.  This mirrors the
+            POSIX ``crypt(3)`` contract that some libcs implement
+            (return non-matching garbage rather than raising).
         """
         # Convert bytes to string if needed
         if isinstance(word, bytes):
             word = word.decode('utf-8')
 
-        # Validate salt format
+        # Tolerate non-SHA-512 salts the way POSIX crypt(3) does.
+        # Sigul's authenticate_admin uses crypt(password, 'xx') as a
+        # constant-time placeholder when the user lookup misses;
+        # raising here would crash the request handler with a
+        # ValueError and the parent server would exit on the next
+        # waitpid() with 'Child died with status 512'.  Return a
+        # value that:
+        #   * is deterministic (so timing is comparable to the
+        #     SHA-512 path),
+        #   * is not equal to the input salt (so the caller's
+        #     ``crypt(pw, x) != x`` check fires and auth_fail runs),
+        #   * does not look like a valid crypt hash.
         if not salt.startswith('$6$'):
-            raise ValueError(
-                f"Only SHA-512 crypt ($6$) is supported, got: {salt[:3]}"
-            )
+            return '!' + salt + '!invalid-crypt-salt'
 
         # Extract salt and optional rounds
         # Format: $6$salt or $6$rounds=N$salt
         parts = salt.split('$')
         if len(parts) < 3:
-            raise ValueError(f"Invalid salt format: {salt}")
+            return '!' + salt + '!invalid-crypt-salt'
 
         # Check if rounds are specified
         if parts[2].startswith('rounds='):


### PR DESCRIPTION
## Summary

When PR-53 landed and the workflow ran, both functional-tests matrix
jobs timed out at 5 minutes.  The server container exited with status
0 the moment the first `list-users` request arrived, the
integration test sat spinning until the timeout, and we couldn't see
why because Sigul's daemon log lives at `/var/log/sigul_<role>.log`
*inside the container* - a path that is not on a persisted volume,
so `docker logs` only captures the entrypoint shell output and every
line written by Python (including all the new `AUTHDBG/*`) was
invisible.

Three commits in this PR:

### 1. `CI(workflows): Capture /var/log/sigul_*.log via docker cp`

`docker cp` works against running and stopped containers, so add a
`docker cp` step to the diagnostics in both `stack-deploy-test` and
`functional-tests` and attach the output to the upload artifacts.
Diagnostic-only - no behaviour change.

This change immediately uncovered the two real bugs that follow.

### 2. `Fix(crypt-shim): Tolerate non-SHA-512 salts like POSIX crypt(3)`

With the daemon log captured, the actual crash on the first request
was clear:

```text
File "/usr/share/sigul/server.py", line 636, in authenticate_admin
    compare_result = crypt.crypt(password, crypted_pw) == crypted_pw
File "/usr/lib/python3.13/site-packages/crypt.py", line 47, in crypt
    raise ValueError(
        f"Only SHA-512 crypt ($6$) is supported, got: {salt[:3]}"
    )
ValueError: Only SHA-512 crypt ($6$) is supported, got: xx
ERROR: Child died with status 512
```

Sigul's `authenticate_admin` deliberately calls
`crypt.crypt(password, 'xx')` as a constant-time placeholder when
the user lookup misses, so timing analysis can't distinguish a
missing user from a wrong password.  POSIX `crypt(3)` returns NULL
or non-matching garbage for an unrecognised salt; raising
`ValueError` is a behaviour change introduced by our shim, and it
crashes the request handler.  Because the parent server treats an
unhandled exception in a child as `_CHILD_BUG`, it breaks out of
the request loop and shuts down on the next `waitpid()`.  **Any**
request naming a non-existent user takes the whole server down.

Make the shim deterministic-but-non-matching for any salt that
isn't `$6$...`, matching the contract Sigul (and other legacy
callers) expect from POSIX crypt.  Real `$6$` hashes still produce
proper SHA-512 results via passlib.

### 3. `CI(workflows): Set user-name in functional-test client.conf`

The functional-tests setup heredoc generates a client.conf
*without* a `[client] user-name` line.  `sigul --batch` then falls
back to `getpass.getuser()` inside the container, which (because
the client runs as the `sigul` user) returns `'sigul'`.  But the
admin user we create on the server side is named `'admin'`.  So
every request authenticates against a user that does not exist,
which - combined with bug 2 - crashes the server.

Pin `user-name: admin` explicitly so the client request matches
the admin user `init_database` creates with `SIGUL_ADMIN_USER`.

## Verification

The crypt shim fix was verified inside the rebuilt server image:

```text
crypt(*, 'xx') -> '!xx!invalid-crypt-salt'  (does not equal 'xx', as
                                              required by Sigul's check)
crypt('hello', '$6$mysalt') -> '$6$mysalt$HjkH9tPwoOZC...'
                                            (real SHA-512 hash)
```

The full integration test suite still passes 10/10 against a fresh
local stack deployed via the same `deploy-sigul-infrastructure.sh`
script CI uses.

## Risk

* Diagnostic step: zero risk.
* Crypt shim: behaviour change for invalid salts only - was raising
  ValueError, now returns a deterministic non-matching string.  Real
  callers that supplied valid `$6$...` salts are unaffected.
* Workflow `user-name`: tightens an under-specified config; fully
  matches the local-debug recipe in `docs/LOCAL_DEBUG.md`.