### PR TITLE
CI(workflows): Add publish_ghcr toggle on workflow_dispatch

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -21,6 +21,15 @@ on:
         type: boolean
         default: false
         required: false
+      publish_ghcr:
+        description: >-
+          Publish the freshly-built images to the GitHub Container
+          Registry (ghcr.io).  Untick to skip publishing - useful
+          when iterating on the workflow itself or running a quick
+          test build that should not change the published images.
+        type: boolean
+        default: true
+        required: false
 
 #  push:
 #    branches: ['main']
@@ -223,7 +232,13 @@ jobs:
     # part-way through arm64.
     timeout-minutes: 10
     needs: [build-containers]
-    if: github.event_name != 'pull_request'
+    # Pull-request triggers never publish.  workflow_dispatch runs
+    # publish by default but a maintainer can untick the
+    # publish_ghcr input to skip the job for quick test builds.
+    if: >-
+      github.event_name != 'pull_request'
+      && (github.event_name != 'workflow_dispatch'
+          || inputs.publish_ghcr)
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length


### PR DESCRIPTION
## Summary

Add a boolean `workflow_dispatch` input `publish_ghcr` (default
`true`) that gates the **Publish to GHCR** job.

Maintainers iterating on the workflow itself, or running a quick
smoke build that should not advance the published images, can
untick the box at dispatch time and skip publication.

## Behaviour

| Trigger | `publish_ghcr` value | Publish runs? |
| --- | --- | --- |
| `pull_request` | n/a | No (unchanged) |
| `workflow_dispatch` | `true` (default) | Yes |
| `workflow_dispatch` | `false` | **No** |
| Other (push, ...) | n/a | Yes |

## Verification

`actionlint` and `yamllint` both clean.  No behaviour change for
the default-tick path.

## Risk

Low.  One-line gate change plus a new optional input.