### PR TITLE
Fix(test/signing): chmod 0777 host workdir so container UID 1000 can write

### DIFF
--- a/scripts/run-signing-tests.sh
+++ b/scripts/run-signing-tests.sh
@@ -86,9 +86,17 @@ fi
 
 # A scratch host directory that we mount into the client container
 # so signed outputs and verifier inputs can live in the same place.
+# We deliberately chmod 0777: the directory is mounted into
+# containers running as the in-image sigul user (UID 1000), which is
+# unrelated to whichever UID the runner shell happens to be using.
+# On macOS Docker silently maps host-side perms via osxfs so 0700
+# also works there, but on Linux runners (which is what CI uses)
+# the container's UID 1000 cannot otherwise write into a directory
+# owned by the runner user.  This dir holds nothing sensitive - all
+# fixture passphrases here are publicly known - so 0777 is fine.
 HOST_WORKDIR="$(mktemp -d /tmp/sigul-signing-tests.XXXXXX)"
 trap 'rm -rf "$HOST_WORKDIR"' EXIT
-chmod 755 "$HOST_WORKDIR"
+chmod 0777 "$HOST_WORKDIR"
 
 # Test counters.
 PASS=0


### PR DESCRIPTION
## Summary

The first CI run of the new signing tests (after PR #56 merged)
failed both `linux/amd64` and `linux/arm64` matrix jobs with the
same root cause:

```text
--- TEST: 1.5  import-key: import the throwaway test fixture
❌ FAIL: Failed to decode test fixture; cannot run import-key test
```

…cascading into test 1.6 (no second key), 1.7 (auth-fail because
the missing key is treated as not-found), and 1.9 (`delete-key` of
the never-imported key).

## Root cause

The signing-tests host scratch directory is created via `mktemp -d`
which produces `0700` perms owned by the calling shell's UID.  That
directory is mounted into containers running as the in-image sigul
user (`UID 1000`), which is unrelated to the runner's UID.

On macOS Docker silently maps host-side perms via osxfs so `0700`
worked locally during development.  On Linux runners (which CI
uses) the container's `UID 1000` cannot write into a directory
owned by the runner user with `0700` perms, so the in-container
fixture-decode step in test 1.5 produced an empty output file.

The host-side `[[ -s "$DECODED_FIXTURE" ]]` check then bailed and
the four downstream tests cascaded.

## Fix

`chmod 0777` the host scratch dir right after `mktemp`.  The
directory holds nothing sensitive (all fixture passphrases here
are publicly known), so loose perms are fine.

## Verification

10/10 still pass locally with the change.  Comments added to
explain the macOS-vs-Linux quirk so future maintainers don't
have to re-discover it.