### PR TITLE
Chore: Address post-merge Copilot feedback from PRs #53, #54, #55

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -938,23 +938,28 @@ jobs:
     timeout-minutes: 1
     # yamllint disable rule:line-length
     steps:
-      - name: 'Generate build summary'
+      - name: 'Generate deploy summary'
         shell: bash
         run: |
           {
             echo "## Sigul Deploy Summary 🐳"
             echo ""
 
-            echo "### Build Results"
-            echo "| Platform | Build | Integration | Status |"
-            echo "|----------|-------|-------------|--------|"
-
-            # Note: In real implementation, check actual job statuses
-            echo "| linux/amd64 | ${{ needs.build-containers.result }} |" \
-              " ${{ needs.functional-tests.result }} | Complete |"
-            echo "| linux/arm64 | ${{ needs.build-containers.result }} |" \
-              " ${{ needs.functional-tests.result }} | Complete |"
+            echo "### Job Results"
+            echo "| Job | Status |"
+            echo "|-----|--------|"
+            echo "| Build (matrix: amd64 + arm64) |" \
+              " ${{ needs.build-containers.result }} |"
+            echo "| Functional Tests (matrix: amd64 + arm64) |" \
+              " ${{ needs.functional-tests.result }} |"
             echo ""
+
+            # Note: needs.<job>.result is the *overall* matrix outcome
+            # ('success' iff every matrix leg passed).  GitHub does not
+            # currently expose per-leg results to a downstream summary
+            # job without explicit job outputs, so we report the
+            # overall status only and let maintainers click into the
+            # individual matrix legs in the UI for per-platform detail.
 
             echo "### Functional Tests"
             echo "- **Status**: ${{ needs.functional-tests.result }}"

--- a/build-scripts/crypt_compat.py
+++ b/build-scripts/crypt_compat.py
@@ -33,8 +33,9 @@ if sys.version_info >= (3, 13):
             salt: The salt string.  Real callers will pass an
                   ``$6$...`` SHA-512 crypt salt; legacy code may
                   also pass a non-crypt placeholder (Sigul, for
-                  example, intentionally calls ``crypt('xx')`` as a
-                  timing-attack guard when the user does not exist).
+                  example, intentionally calls
+                  ``crypt(password, 'xx')`` as a timing-attack
+                  guard when the user does not exist).
 
         Returns:
             The hashed password string in crypt format, or - for
@@ -55,11 +56,16 @@ if sys.version_info >= (3, 13):
         # ValueError and the parent server would exit on the next
         # waitpid() with 'Child died with status 512'.  Return a
         # value that:
-        #   * is deterministic (so timing is comparable to the
-        #     SHA-512 path),
+        #   * is deterministic,
         #   * is not equal to the input salt (so the caller's
         #     ``crypt(pw, x) != x`` check fires and auth_fail runs),
         #   * does not look like a valid crypt hash.
+        # NOTE: this fast-path does NOT preserve the timing parity
+        # the upstream timing-attack guard relies on - it returns
+        # immediately rather than performing equivalent work to the
+        # SHA-512 path.  Re-implementing parity here would require
+        # invoking sha512_crypt with a synthesised salt and is not
+        # worth the complexity for a placeholder-salt code path.
         if not salt.startswith('$6$'):
             return '!' + salt + '!invalid-crypt-salt'
 

--- a/patches/02-verbose-auth-logging.patch
+++ b/patches/02-verbose-auth-logging.patch
@@ -99,7 +99,7 @@ index 25d713d..09d3dcc 100644
                  BridgeConnection.handle_connection(config, client_sock,
                                                     server_sock)
 diff --git a/src/server.py b/src/server.py
-index bf73fcb..dd3a9a0 100644
+index bf73fcb..67bcfef 100644
 --- a/src/server.py
 +++ b/src/server.py
 @@ -58,6 +58,26 @@ import server_gpg as ourgpg
@@ -160,7 +160,7 @@ index bf73fcb..dd3a9a0 100644
          self.send_error(errors.AUTHENTICATION_FAILED, log_it=False)
 
      def _verify_username(self, outer_user):
-@@ -576,25 +610,39 @@ class ServersConnection(object):
+@@ -576,25 +610,45 @@ class ServersConnection(object):
          Raise RequestHandled (on permission denied), InvalidRequestError.
          '''
          user = self.safe_outer_field('user')
@@ -188,12 +188,19 @@ index bf73fcb..dd3a9a0 100644
              # Perform the encryption anyway to make timing attacks more
              # difficult.
              crypted_pw = 'xx'
+-        if (crypt.crypt(password, crypted_pw) != crypted_pw
 +            _adbg('authenticate_admin: NO stored sha512_password '
 +                  '(user_row=%s)', user_row is not None)
-+        compare_result = crypt.crypt(password, crypted_pw) == crypted_pw
++        # Compute crypt() once and reuse the result for both the
++        # diagnostic log line and the actual compare.  Computing it
++        # twice would change CPU/timing cost even when SIGUL_DEBUG_AUTH
++        # is unset (because the if-condition below also computes it),
++        # which contradicts the patch's no-behaviour-change guarantee.
++        crypt_result = crypt.crypt(password, crypted_pw)
 +        _adbg('authenticate_admin: crypt compare result=%s '
-+              '(user existed=%s)', compare_result, crypted_pw != 'xx')
-         if (crypt.crypt(password, crypted_pw) != crypted_pw
++              '(user existed=%s)',
++              crypt_result == crypted_pw, crypted_pw != 'xx')
++        if (crypt_result != crypted_pw
                  or crypted_pw == 'xx'):
              self.auth_fail('password does not match')
 -        if not user.admin:
@@ -204,14 +211,24 @@ index bf73fcb..dd3a9a0 100644
          # OK
 
      def __authenticate_admin_or_user(self, db):
-@@ -2812,6 +2860,10 @@ def request_handling_child(config):
+@@ -2812,6 +2866,20 @@ def request_handling_child(config):
          try:
              logging.debug('Waiting for a request')
              handler = conn.read_request()
-+            _adbg('request_handling_child: handler=%r peer_cn=%r',
-+                  type(handler).__name__,
-+                  conn.peer_subject().common_name
-+                  if hasattr(conn, 'peer_subject') else '?')
++            # Gate the peer_subject lookup behind the debug-enabled
++            # check.  Python evaluates function arguments eagerly, so
++            # without this guard the conn.peer_subject().common_name
++            # call would happen on every request even when
++            # SIGUL_DEBUG_AUTH is unset - and could change control
++            # flow if peer_subject() ever raised.  We want
++            # disabled-debug to be byte-for-byte identical to upstream.
++            if _auth_debug_enabled():
++                try:
++                    _peer_cn = conn.peer_subject().common_name
++                except Exception:
++                    _peer_cn = '?'
++                _adbg('request_handling_child: handler=%r peer_cn=%r',
++                      type(handler).__name__, _peer_cn)
              handler.handler(db, conn)
          finally:
              try:

--- a/scripts/init-client-certs.sh
+++ b/scripts/init-client-certs.sh
@@ -376,8 +376,16 @@ finalize_ownership() {
     # error from upstream.  No-op when the script is already running
     # as the target user.
     if [[ "$(id -u)" -eq 0 ]]; then
-        log "Running as root - chowning $CLIENT_NSS_DIR to sigul user"
-        chown -R 1000:1000 "$CLIENT_NSS_DIR" \
+        # Resolve target UID/GID dynamically from the sigul account
+        # in the running image to stay in lock-step with the
+        # entrypoints (which also use id -u sigul / id -g sigul).
+        # Hard-coding 1000 here would re-introduce the same drift
+        # the entrypoints fixed.
+        local target_uid target_gid
+        target_uid="$(id -u sigul 2>/dev/null || echo 1000)"
+        target_gid="$(id -g sigul 2>/dev/null || echo 1000)"
+        log "Running as root - chowning $CLIENT_NSS_DIR to ${target_uid}:${target_gid}"
+        chown -R "${target_uid}:${target_gid}" "$CLIENT_NSS_DIR" \
             || warn "Failed to chown $CLIENT_NSS_DIR"
     fi
 }

--- a/scripts/init-server-certs.sh
+++ b/scripts/init-server-certs.sh
@@ -383,8 +383,16 @@ main() {
     # this is belt-and-braces so init-server-certs is correct when
     # invoked stand-alone for debugging too.
     if [[ "$(id -u)" -eq 0 ]]; then
-        log "Running as root - chowning $SERVER_NSS_DIR to sigul user"
-        chown -R 1000:1000 "$SERVER_NSS_DIR" \
+        # Resolve target UID/GID dynamically from the sigul account
+        # in the running image to stay in lock-step with the
+        # entrypoints (which also use id -u sigul / id -g sigul).
+        # Hard-coding 1000 here would re-introduce the same drift
+        # the entrypoints fixed.
+        local target_uid target_gid
+        target_uid="$(id -u sigul 2>/dev/null || echo 1000)"
+        target_gid="$(id -g sigul 2>/dev/null || echo 1000)"
+        log "Running as root - chowning $SERVER_NSS_DIR to ${target_uid}:${target_gid}"
+        chown -R "${target_uid}:${target_gid}" "$SERVER_NSS_DIR" \
             || warn "Failed to chown $SERVER_NSS_DIR"
     fi
 

--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -469,13 +469,25 @@ test_header "Batch Mode Password Input (NUL-terminated)"
 # "auto_generated_ephemeral" which is the docker-compose default fallback;
 # any deployment that supplies a real password would always fail this
 # test even with a fully working stack.  Use $ADMIN_PASSWORD instead.
+#
+# We pass the password via -e ADMIN_PASSWORD rather than interpolating
+# it into the bash -c string.  Direct interpolation would break (and
+# could in principle become a shell-injection vector) if the password
+# ever contained special characters; the env-var approach is robust
+# to any byte sequence and the inner bash uses single-quoted command
+# text, which never expands $ADMIN_PASSWORD on the host.
+# shellcheck disable=SC2016
+# (the single-quoted bash -c body is intentional - we want
+# $ADMIN_PASSWORD to be expanded inside the container, not on the
+# host - so SC2016 is a false positive here.)
 OUTPUT=$(timeout 60 docker run --rm \
     --user 1000:1000 \
     --network "$NETWORK" \
     -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
     -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
+    -e ADMIN_PASSWORD="${ADMIN_PASSWORD}" \
     "$CLIENT_IMAGE" \
-    bash -c "printf '%s\0' '${ADMIN_PASSWORD}' | sigul --batch -c /etc/sigul/client.conf list-users 2>&1")
+    bash -c 'printf "%s\0" "$ADMIN_PASSWORD" | sigul --batch -c /etc/sigul/client.conf list-users 2>&1')
 
 if echo "$OUTPUT" | grep -q "admin"; then
     pass "Batch mode NUL-terminated password works correctly"

--- a/scripts/sync-local-sigul.sh
+++ b/scripts/sync-local-sigul.sh
@@ -68,6 +68,11 @@ fi
 while [ $# -gt 0 ]; do
     case "$1" in
         --source)
+            if [ $# -lt 2 ]; then
+                echo "Error: --source requires a directory argument" >&2
+                usage >&2
+                exit 2
+            fi
             SRC="$2"
             shift 2
             ;;
@@ -88,10 +93,17 @@ while [ $# -gt 0 ]; do
 done
 
 if [ "$CLEAN" -eq 1 ]; then
-    echo "Removing any previously-synced sigul source from ${DEST}"
-    # Preserve the .gitkeep so the path is still legal in Dockerfiles
-    find "${DEST}" -mindepth 1 -not -name '.gitkeep' -delete
-    echo "Done.  Next docker build will clone Sigul from upstream."
+    if [ -d "${DEST}" ]; then
+        echo "Removing any previously-synced sigul source from ${DEST}"
+        # Preserve the .gitkeep so the path is still legal in
+        # Dockerfiles after the wipe.
+        find "${DEST}" -mindepth 1 -not -name '.gitkeep' -delete
+        echo "Done.  Next docker build will clone Sigul from upstream."
+    else
+        # Nothing to clean - --clean is idempotent and a no-op when
+        # the destination doesn't exist yet.
+        echo "Nothing to clean: ${DEST} does not exist."
+    fi
     exit 0
 fi
 
@@ -128,7 +140,12 @@ else
     if [ -f "${DEST}/.gitkeep" ]; then
         cp "${DEST}/.gitkeep" "${keepfile}"
     fi
-    rm -rf "${DEST:?}/"*
+    # Mimic 'rsync --delete' semantics: remove regular files AND
+    # dotfiles/dotdirs (e.g. .github, .pytest_cache).  Plain
+    # 'rm -rf ${DEST:?}/*' does not match dotted entries so they
+    # would otherwise survive into the new tree.
+    find "${DEST}" -mindepth 1 -not -name '.gitkeep' \
+        -exec rm -rf {} +
     if [ -s "${keepfile}" ]; then
         cp "${keepfile}" "${DEST}/.gitkeep"
     fi


### PR DESCRIPTION
## Summary

Sweep PR addressing Copilot feedback that landed on **PRs #53, #54
and #55 after they were merged**.  Those review threads were never
seen during the merge cycle and contained a mix of cosmetic
clean-ups and **real correctness findings** that warranted a
follow-up.

Six atomic, independently-revertable commits.

## Findings addressed

### From PR #53 (`Fix(stack): Resolve silent auth/permission failures...`)

| Severity | Commit | What was found |
| --- | --- | --- |
| **Real** | `Refactor(patches): Tighten 02-verbose-auth-logging guarantees` | `_adbg(...)` in `request_handling_child` eagerly evaluated `conn.peer_subject().common_name` even when `SIGUL_DEBUG_AUTH` was unset (Python evaluates function args eagerly).  Could change control flow if `peer_subject()` ever raised, contradicting the patch's "byte-for-byte identical to upstream when disabled" guarantee.  Also: `crypt.crypt()` was being computed twice in `authenticate_admin`, doubling CPU/timing cost on every request even with debug off.  Both fixed. |
| **Real** | `Fix(scripts): Resolve UID/GID dynamically...` | `init-{client,server}-certs.sh` hard-coded `chown -R 1000:1000`, drifting from the entrypoints which had already moved to `id -u sigul`.  Re-aligned to use the same dynamic lookup. |
| **Real** | `Fix(scripts): Harden sync-local-sigul.sh edge cases` | Three sub-findings: (a) `--source` with no value triggered an unbound-variable error under `set -u`; (b) `--clean` ran `find` on a possibly-nonexistent directory; (c) the tar fallback used `rm -rf ${DEST:?}/*` which doesn't match dotfiles, leaking stale state. |
| Low | `Fix(tests): Pass admin password via env var, not bash -c interpolation` | Test 10 in `run-integration-tests.sh` interpolated `$ADMIN_PASSWORD` into a `bash -c "..."` string; latent shell-injection surface (the password is publicly-known ephemeral, but worth fixing for correctness). |

### From PR #54 (`Fix(stack): Capture daemon logs, harden crypt shim, set user-name`)

| Severity | Commit | What was found |
| --- | --- | --- |
| Cosmetic | `Docs(crypt-shim): Fix docstring typo and clarify timing claim` | Docstring example showed `crypt('xx')` (missing required `password` arg).  Also corrected the comment claim that the placeholder fast-path produces "timing comparable to the SHA-512 path" - it doesn't, and we now say so explicitly. |

### From PR #55 (`CI(workflows): Drop stack-deploy-test, bump GHCR timeout, rename summary`)

| Severity | Commit | What was found |
| --- | --- | --- |
| Cosmetic | `CI(workflows): Drop misleading per-platform rows...` | The Deploy Summary step name was still `'Generate build summary'` after the job was renamed.  And the per-platform rows in the summary table both used the *overall* matrix outcome, so they always reported identical values; the `Status` column was hard-coded to `Complete` even on failure. |

## Verification

* `actionlint` and `yamllint` clean on workflow change
* `shellcheck` clean on all script changes
* Integration tests still 10/10 PASS (verified after the bash-c
  refactor)
* Patch 02 still applies cleanly to upstream Sigul v1.4 after
  patch 01 is applied first; `python3 -c "import ast"` parses the
  result without error

## Risk

Low.  Each commit is small, well-bounded and independently
revertable.  No image rebuild required for any of these fixes -
they all apply to scripts and the patch file at runtime.

## Notes

PR #56's Copilot feedback (Phase 1 signing tests) had no
findings, and PR #60's two findings have already been addressed
in the PR-C branch directly.