### PR TITLE
Feat(test): Phase 4 - user and key-access lifecycle

### DIFF
--- a/scripts/run-integration-tests.sh
+++ b/scripts/run-integration-tests.sh
@@ -473,9 +473,12 @@ test_header "Batch Mode Password Input (NUL-terminated)"
 # We pass the password via -e ADMIN_PASSWORD rather than interpolating
 # it into the bash -c string.  Direct interpolation would break (and
 # could in principle become a shell-injection vector) if the password
-# ever contained special characters; the env-var approach is robust
-# to any byte sequence and the inner bash uses single-quoted command
-# text, which never expands $ADMIN_PASSWORD on the host.
+# ever contained special shell characters; passing the value via
+# 'docker run -e' and dereferencing it inside a single-quoted
+# bash -c avoids interpolation on the host entirely.  Note that
+# environment variables (and Bash strings) cannot carry NUL bytes -
+# which is why the inner 'printf %s\0' adds the NUL terminator at
+# use time rather than embedding one in the password value.
 # shellcheck disable=SC2016
 # (the single-quoted bash -c body is intentional - we want
 # $ADMIN_PASSWORD to be expanded inside the container, not on the

--- a/scripts/run-signing-tests.sh
+++ b/scripts/run-signing-tests.sh
@@ -32,10 +32,12 @@
 #          a 64 MiB large-payload streaming test).
 # Phase 3: RPM signing (sign-rpm, sign-rpm --v3-signature,
 #          sign-rpms batch).  Independently verified with rpm -K.
-#
-# Future PRs will add:
 # Phase 4: User and key-access lifecycle (new-user,
 #          grant-key-access, revoke-key-access, delete-user).
+#          Verifies that authorisation actually constrains who can
+#          sign with which key.
+#
+# Future PRs will add (none currently planned).
 #
 # Usage
 # -----
@@ -939,6 +941,289 @@ if [[ $BATCH_VERIFY_FAILS -eq 0 ]]; then
     pass "rpm -Kv accepts all 3 RPMs from the sign-rpms batch"
 else
     fail "${BATCH_VERIFY_FAILS}/3 batch-signed RPMs failed verification"
+fi
+
+# ----------------------------------------------------------------------
+# PHASE 4: User and key-access lifecycle
+# ----------------------------------------------------------------------
+#
+# Phase 1-3 used the admin account exclusively.  Phase 4 verifies
+# that Sigul's authorisation model actually constrains who can do
+# what:
+#
+#  * a freshly-created non-admin user can NOT call admin-only ops
+#    like list-users;
+#  * a freshly-created non-admin user can NOT sign with an
+#    arbitrary key they have not been granted access to;
+#  * once an admin grants the user access to a specific key,
+#    they CAN sign with it (and the resulting signature still
+#    verifies);
+#  * once access is revoked, they can no longer sign with it;
+#  * delete-user removes them entirely.
+#
+# These are the tests that exercise the protocol design described
+# in sigul/doc/protocol-design.txt under "ADMIN REQUESTS",
+# "KEY ADMIN REQUESTS" and "USER REQUESTS".  Without them, a
+# regression in the auth code could go undetected: every previous
+# phase used the same admin user.
+
+phase "4: USER AND KEY-ACCESS LIFECYCLE"
+
+TEST_USER="ci-test-user"
+export SIGUL_TEST_PW_TESTUSER="ci-test-user-password"
+export SIGUL_TEST_PW_TESTUSER_KEY="ci-test-user-key-passphrase"
+
+note "Test user: ${TEST_USER}"
+note "Re-using ${NEW_KEY_NAME} (the key created in phase 1) for the"
+note "grant/revoke/sign-as-grantee tests.  The key passphrase has"
+note "been rotated to NEWKEY_NEW."
+
+# Best-effort cleanup of any leftover ${TEST_USER} from a previous
+# run.  This is the same defensive pattern Phase 0 uses for keys.
+note "Best-effort delete of any leftover ${TEST_USER} (ignoring errors)"
+printf '%s\0' "$ADMIN_PASSWORD" \
+    | docker run --rm -i \
+        --user 1000:1000 \
+        --network "$NETWORK" \
+        -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
+        -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
+        "$CLIENT_IMAGE" \
+        bash -c "sigul --batch -c /etc/sigul/client.conf \
+            delete-user ${TEST_USER} 2>&1" \
+    || true
+
+# ----------------------------------------------------------------------
+testcase "4.1  new-user --with-password: create a non-admin test user"
+
+note "new-user without --admin creates a regular (non-admin) user."
+note "--with-password defines a password for that user, which is"
+note "what they'll use to authenticate non-key admin operations."
+note "new-user feeds two passphrases on stdin: the admin password"
+note "first, then the new user's password."
+
+if sigul_run "ADMIN,TESTUSER" "sigul --batch -c /etc/sigul/client.conf \\
+    new-user --with-password ${TEST_USER}"; then
+    pass "new-user returned without error"
+else
+    fail "new-user exited non-zero"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.2  user-info: confirm the user exists and is NOT admin"
+
+USER_INFO_OUT=$(
+    _sigul_emit "ADMIN" "sigul --batch -c /etc/sigul/client.conf \
+        user-info ${TEST_USER}" 2>&1
+)
+echo "$USER_INFO_OUT"
+if grep -qi 'administrator: *no' <<< "$USER_INFO_OUT"; then
+    pass "user-info reports ${TEST_USER} with admin=no"
+else
+    fail "user-info did NOT report ${TEST_USER} as admin=no"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.3  Negative: ${TEST_USER} CANNOT call admin-only list-users"
+
+note "This test invokes sigul as the new user via -u ${TEST_USER}."
+note "list-users is an admin-only operation per the protocol design;"
+note "a non-admin user should be rejected with AUTHENTICATION_FAILED."
+
+NEG_OUT=$(
+    printf '%s\0' "$SIGUL_TEST_PW_TESTUSER" \
+        | docker run --rm -i \
+            --user 1000:1000 \
+            --network "$NETWORK" \
+            -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
+            -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
+            "$CLIENT_IMAGE" \
+            bash -c "sigul --batch -u ${TEST_USER} \
+                -c /etc/sigul/client.conf list-users 2>&1" \
+        || true
+)
+echo "$NEG_OUT"
+if grep -qi 'authentication failed' <<< "$NEG_OUT"; then
+    pass "server correctly rejects non-admin list-users"
+else
+    fail "server did NOT reject non-admin list-users"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.4  Negative: ${TEST_USER} CANNOT yet sign with ${NEW_KEY_NAME}"
+
+note "Without grant-key-access the user has no key access record;"
+note "sign-text should be rejected at the auth layer."
+
+showrun "echo 'pre-grant test message' \\
+    > '$(hostpath /work/pre-grant.txt)'"
+
+NEG_OUT=$(
+    printf '%s\0' "$SIGUL_TEST_PW_TESTUSER" \
+        | docker run --rm -i \
+            --user 1000:1000 \
+            --network "$NETWORK" \
+            -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
+            -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
+            -v "${HOST_WORKDIR}:/work:rw" \
+            "$CLIENT_IMAGE" \
+            bash -c "sigul --batch -u ${TEST_USER} \
+                -c /etc/sigul/client.conf \
+                sign-text -o /work/pre-grant.signed.txt \
+                ${NEW_KEY_NAME} /work/pre-grant.txt 2>&1" \
+        || true
+)
+echo "$NEG_OUT"
+if grep -qi 'authentication failed' <<< "$NEG_OUT"; then
+    pass "server correctly rejects sign-text from un-granted user"
+else
+    fail "server did NOT reject sign-text from un-granted user"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.5  grant-key-access: admin grants ${TEST_USER} access to ${NEW_KEY_NAME}"
+
+note "grant-key-access feeds two passphrases on stdin: the existing"
+note "key passphrase first (so the server can re-wrap), then the new"
+note "per-user passphrase the grantee will use to sign with the key."
+
+if sigul_run "NEWKEY,TESTUSER_KEY" \
+    "sigul --batch -c /etc/sigul/client.conf \\
+        grant-key-access ${NEW_KEY_NAME} ${TEST_USER}"; then
+    pass "grant-key-access returned without error"
+else
+    fail "grant-key-access exited non-zero"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.6  list-key-users: confirm ${TEST_USER} is listed for ${NEW_KEY_NAME}"
+
+LKU_OUT=$(
+    _sigul_emit "ADMIN" "sigul --batch \
+        -c /etc/sigul/client.conf list-key-users \
+        --password ${NEW_KEY_NAME}" 2>&1
+)
+echo "$LKU_OUT"
+if grep -q "^${TEST_USER}$" <<< "$LKU_OUT"; then
+    pass "list-key-users includes ${TEST_USER}"
+else
+    fail "list-key-users does NOT include ${TEST_USER}"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.7  ${TEST_USER} CAN now sign-text with ${NEW_KEY_NAME}"
+
+note "After grant, the user signs using their per-user key passphrase"
+note "(TESTUSER_KEY), NOT the original key passphrase.  The server"
+note "unwraps the per-user copy and uses the underlying GPG key."
+note "We verify the signature with the same host-side keyring set up"
+note "in Phase 2."
+
+showrun "echo 'post-grant test message - signed by ${TEST_USER}' \\
+    > '$(hostpath /work/post-grant.txt)'"
+
+if printf '%s\0' "$SIGUL_TEST_PW_TESTUSER_KEY" \
+    | docker run --rm -i \
+        --user 1000:1000 \
+        --network "$NETWORK" \
+        -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
+        -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
+        -v "${HOST_WORKDIR}:/work:rw" \
+        "$CLIENT_IMAGE" \
+        bash -c "sigul --batch -u ${TEST_USER} \
+            -c /etc/sigul/client.conf \
+            sign-text -o /work/post-grant.signed.txt \
+            ${NEW_KEY_NAME} /work/post-grant.txt"; then
+    pass "sign-text as ${TEST_USER} returned without error"
+else
+    fail "sign-text as ${TEST_USER} exited non-zero"
+fi
+
+if [[ -s "$(hostpath /work/post-grant.signed.txt)" ]]; then
+    showrun "head -3 '$(hostpath /work/post-grant.signed.txt)'"
+    VERIFY_OUT_PG="$(hostpath /work/post-grant.recovered.txt)"
+    showrun "GNUPGHOME='${VERIFY_GPGHOME}' gpg --batch --yes \\
+        --output '${VERIFY_OUT_PG}' \\
+        --decrypt '$(hostpath /work/post-grant.signed.txt)' 2>&1"
+    if diff -u "$(hostpath /work/post-grant.txt)" "$VERIFY_OUT_PG" \
+            >/dev/null; then
+        pass "signature by ${TEST_USER} verifies and content round-trips"
+    else
+        fail "signature by ${TEST_USER} verified but content differs"
+    fi
+else
+    fail "sign-text output is empty; cannot verify"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.8  revoke-key-access: admin revokes ${TEST_USER}'s access"
+
+note "revoke-key-access can be invoked by an admin (--password) or"
+note "by a key admin.  The admin path is what we exercise here."
+
+if sigul_run "ADMIN" "sigul --batch \\
+    -c /etc/sigul/client.conf \\
+    revoke-key-access --password ${NEW_KEY_NAME} ${TEST_USER}"; then
+    pass "revoke-key-access returned without error"
+else
+    fail "revoke-key-access exited non-zero"
+fi
+
+LKU2_OUT=$(
+    _sigul_emit "ADMIN" "sigul --batch \
+        -c /etc/sigul/client.conf list-key-users \
+        --password ${NEW_KEY_NAME}" 2>&1
+)
+echo "$LKU2_OUT"
+if grep -q "^${TEST_USER}$" <<< "$LKU2_OUT"; then
+    fail "list-key-users still includes ${TEST_USER} after revoke"
+else
+    pass "list-key-users no longer includes ${TEST_USER}"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.9  Negative: ${TEST_USER} CAN NO LONGER sign with ${NEW_KEY_NAME}"
+
+NEG_OUT=$(
+    printf '%s\0' "$SIGUL_TEST_PW_TESTUSER_KEY" \
+        | docker run --rm -i \
+            --user 1000:1000 \
+            --network "$NETWORK" \
+            -v "${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro" \
+            -v "${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro" \
+            -v "${HOST_WORKDIR}:/work:rw" \
+            "$CLIENT_IMAGE" \
+            bash -c "sigul --batch -u ${TEST_USER} \
+                -c /etc/sigul/client.conf \
+                sign-text -o /work/post-revoke.signed.txt \
+                ${NEW_KEY_NAME} /work/post-grant.txt 2>&1" \
+        || true
+)
+echo "$NEG_OUT"
+if grep -qi 'authentication failed' <<< "$NEG_OUT"; then
+    pass "server correctly rejects sign-text after revoke"
+else
+    fail "server did NOT reject sign-text after revoke"
+fi
+
+# ----------------------------------------------------------------------
+testcase "4.10  delete-user: tear down ${TEST_USER} for clean re-runs"
+
+if sigul_run "ADMIN" "sigul --batch -c /etc/sigul/client.conf \\
+    delete-user ${TEST_USER}"; then
+    pass "delete-user returned without error"
+else
+    fail "delete-user exited non-zero"
+fi
+
+LU_OUT=$(
+    _sigul_emit "ADMIN" "sigul --batch -c /etc/sigul/client.conf \
+        list-users" 2>&1
+)
+echo "$LU_OUT"
+if grep -q "^${TEST_USER}$" <<< "$LU_OUT"; then
+    fail "list-users still includes ${TEST_USER} after delete"
+else
+    pass "list-users no longer includes ${TEST_USER}"
 fi
 
 # ----------------------------------------------------------------------

--- a/scripts/sync-local-sigul.sh
+++ b/scripts/sync-local-sigul.sh
@@ -143,9 +143,11 @@ else
     # Mimic 'rsync --delete' semantics: remove regular files AND
     # dotfiles/dotdirs (e.g. .github, .pytest_cache).  Plain
     # 'rm -rf ${DEST:?}/*' does not match dotted entries so they
-    # would otherwise survive into the new tree.
+    # would otherwise survive into the new tree.  The '--' before
+    # '{}' prevents rm from treating any source path that begins
+    # with '-' as an option flag.
     find "${DEST}" -mindepth 1 -not -name '.gitkeep' \
-        -exec rm -rf {} +
+        -exec rm -rf -- {} +
     if [ -s "${keepfile}" ]; then
         cp "${keepfile}" "${DEST}/.gitkeep"
     fi


### PR DESCRIPTION
## Summary

Phase 4 of the end-to-end signing tests: **user and key-access
lifecycle**.  Verifies that Sigul's authorisation model actually
constrains who can do what — Phases 1-3 used the admin account
exclusively, so a regression in the auth code could otherwise
have gone undetected.

Two commits.

## Phase 4 tests

| # | Operation | Verification |
| --- | --- | --- |
| 4.1 | `new-user --with-password` (regular, non-admin) | exit 0 |
| 4.2 | `user-info` shows the user with `Administrator: no` | grep |
| 4.3 | **Negative**: new user CANNOT call admin-only `list-users` | server returns `AUTHENTICATION_FAILED` |
| 4.4 | **Negative**: new user CANNOT yet sign with `ci-test-new-key` | server returns `AUTHENTICATION_FAILED` |
| 4.5 | `grant-key-access`: admin grants the new user access to the key, with a per-user passphrase distinct from the original key passphrase | exit 0 |
| 4.6 | `list-key-users` includes the granted user | grep |
| 4.7 | New user CAN now sign-text with the key, using their own per-user passphrase | `gpg --verify` + content round-trip diff |
| 4.8 | `revoke-key-access`: admin revokes | exit 0; `list-key-users` no longer shows them |
| 4.9 | **Negative**: revoked user CAN NO LONGER sign | server returns `AUTHENTICATION_FAILED` |
| 4.10 | `delete-user` | exit 0; `list-users` no longer shows them |

## Notes for future readers

A few `--password` placement gotchas surfaced during development:

- `--password` is a **sub-command** option on `list-key-users` and
  `revoke-key-access`, NOT a global one.  It must come *after* the
  subcommand name (e.g. `list-key-users --password <key>`).
- The negative tests use `sigul -u <user>` (a global override) to
  authenticate as a non-admin user without changing the
  `[client] user-name` setting in `client.conf`.

## Verification

```text
========================================================================
== TEST SUMMARY
========================================================================

  Passed: 41
  Failed: 0

\u2705 ALL SIGNING TESTS PASSED
```

10 (Phase 1) + 8 (Phase 2) + 10 (Phase 3) + 13 (Phase 4) PASS
locally against the same `scripts/deploy-sigul-infrastructure.sh`
stack CI uses.

## Commits

1. **`Test(signing): Add phase 4 - user and key-access lifecycle`** — the
   test cases above.
2. **`Fix(scripts): Address Copilot feedback from PR #61`** —
   addresses the two findings from PR #61's post-merge Copilot review:
   - `sync-local-sigul.sh` tar fallback: pass `--` to `rm -rf`
     so paths starting with `-` aren't misinterpreted as options.
   - `run-integration-tests.sh` comment: env vars cannot carry NUL
     bytes - reword the "robust to any byte sequence" claim to be
     accurate about the limitation.

## Risk

Low.  Tests only — no image rebuild required.

## Roadmap

| | |
| --- | --- |
| ✅ PR-A | Phase 1 — key lifecycle |
| ✅ PR-B | Phase 2 — text + binary signing including 64 MiB |
| ✅ PR-C | Phase 3 — RPM signing |
| **This PR (PR-D)** | Phase 4 — user + key-access lifecycle |
| Next | Sigul patch: fix `delete-key` not cleaning `gnupg-home` |
| Then | `fedora:41` → `fedora:44` base-image migration |