### PR TITLE
CI(workflows): Bump build-containers timeout 6 -> 15 minutes

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -59,7 +59,15 @@ jobs:
     permissions:
       contents: read
       actions: write  # Required for cache deletion when clear_cache is true
-    timeout-minutes: 6
+    # Cold builds (no buildx cache hit) compile a stack of dnf updates,
+    # ~180 packages from the Fedora repos and a Sigul source build, all
+    # of which are IO-bound on the runner.  6 minutes was just enough
+    # for warm-cache builds and started timing out reliably once the
+    # registry cache importer broke ("connection refused" on localhost).
+    # Cap generously - the job is bounded by external repo throughput
+    # rather than CPU, so a wider budget costs little but provides
+    # headroom against transient mirror slowdowns.
+    timeout-minutes: 15
     env:
       GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     strategy:


### PR DESCRIPTION
## Summary

The latest workflow runs against `main` are reliably timing out
all six matrix-leg builds at the 6-minute hard cap:

```text
X Build: client (linux/arm64)  6m1s   exceeded maximum execution time of 6m0s
X Build: client (linux/amd64)  6m52s  exceeded maximum execution time of 6m0s
X Build: server (linux/arm64)  6m4s   ...
X Build: bridge (linux/arm64)  6m14s  ...
X Build: server (linux/amd64)  6m15s  ...
X Build: bridge (linux/amd64)  6m14s  ...
```

(run https://github.com/modeseven-lfreleng-actions/sigul-docker/actions/runs/25471926608)

## Root cause

Cold builds (no buildx cache hit) compile a stack of:

- `dnf update` (~2 minutes)
- ~180 Fedora packages installed via `dnf install`
- python-nss-ng from PyPI
- Sigul source clone + autoreconf + make from upstream Pagure

…all IO-bound on the runner.  6 minutes was just enough for
warm-cache builds.  Cold builds were always tight and tipped
over once the **registry cache importer broke** with
`failed to do request: Head "http://localhost/v2/null/manifests/latest": dial tcp [::1]:80: connect: connection refused`
at the start of every recent run, forcing every layer to be
rebuilt cold.

## Fix

Bump `timeout-minutes` from 6 to 15.  The job is bounded by
external repo throughput rather than CPU, so a wider budget
costs little but provides headroom against transient mirror
slowdowns.

This matches the rationale used for the `publish-ghcr` job's
3 → 10 minute bump in PR #57.

## Risk

None.  Larger timeout only - successful warm-cache builds still
finish in ~30-50 seconds and are unaffected.