### PR TITLE
Fix(stack): Sigul patch for delete-key gnupg-home cleanup + test 4.4 correctness

### DIFF
--- a/patches/03-fix-delete-key-gpg-home-cleanup.patch
+++ b/patches/03-fix-delete-key-gpg-home-cleanup.patch
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+#
+# Fix: delete-key actually removes the key from the GnuPG home.
+#
+# Sigul wraps gpgme's delete operation in
+# ``server_gpg.Context.delete(key, delete_secret)``, which calls
+# the legacy ``op_delete(key, allow_secret_bool)`` interface.
+# In python-gpg >= 1.23 this legacy call is a silent no-op:
+# gpgme_op_delete is deprecated, the python wrapper does not raise,
+# and the secret/public key material stays in the gnupg-home.
+#
+# As a result, ``sigul delete-key`` removes the row from the
+# server's sqlite DB (so ``sigul list-keys`` no longer reports the
+# key) but leaves the underlying GPG key material in place.  A
+# subsequent ``sigul import-key`` for the same fingerprint then
+# fails with::
+#
+#     Error: Invalid import file: Unexpected import file contents
+#
+# because gpg reports the key as already-imported.
+#
+# Switch to the modern ``op_delete_ext(key, mode_flags)`` API which
+# actually deletes the key, with the flags
+# (DELETE_ALLOW_SECRET | DELETE_FORCE) we want for sigul's use case.
+#
+# Verified
+# --------
+# Tested standalone with python-gpg 1.23.2:
+#
+#     ctx.create_key(...)
+#     ctx.op_delete(key, True)        # returns; keylist unchanged
+#     ctx.op_delete_ext(key, 1 | 2)   # returns; keylist now empty
+#
+# After this patch, scripts/run-signing-tests.sh's Phase 0 reset
+# (which currently wipes the gnupg-home as a workaround for this
+# bug) becomes a no-op on a clean stack and could be removed in a
+# follow-up cleanup.
+#
+# Companion to patches 01 and 02; applied after both.
+
+diff --git a/src/server_gpg.py b/src/server_gpg.py
+--- a/src/server_gpg.py
++++ b/src/server_gpg.py
+@@ -55,7 +55,24 @@ try:
+             return self.engine_info.version[0] == "2"
+
+         def delete(self, key, delete_secret):
+-            return self.op_delete(key, delete_secret)
++            # python-gpg 1.23+ silently no-ops the legacy
++            # ``op_delete(key, allow_secret_bool)`` call.  The result
++            # is that sigul's gpg_delete_key() removes the row from
++            # its sqlite DB (so 'list-keys' no longer shows the key)
++            # but leaves the underlying GPG key material in the
++            # server's gnupg-home untouched.  A subsequent
++            # 'sigul import-key' for the same fingerprint then fails
++            # with 'Unexpected import file contents' because gpg
++            # reports the key as already-imported.
++            #
++            # Switch to the modern ``op_delete_ext(key, mode_flags)``
++            # API which actually deletes.  The flags are taken from
++            # the GPGME_DELETE_* enum:
++            #   ALLOW_SECRET = 1   permit deletion of secret keys
++            #   FORCE        = 2   do not prompt for confirmation
++            mode = gpg.constants.DELETE_ALLOW_SECRET if delete_secret else 0
++            mode |= gpg.constants.DELETE_FORCE
++            return self.op_delete_ext(key, mode)
+
+         def edit(self, key, func, sink):
+             def wrapper(*args, **kwargs):

--- a/patches/README.md
+++ b/patches/README.md
@@ -44,6 +44,79 @@ double-TLS communication.
 - Adds server certificate validation
 - Adds error handling for handshake failures
 
+### 02-verbose-auth-logging.patch
+
+**Status:** Optional - controlled by `SIGUL_DEBUG_AUTH` env var
+**Upstream Status:** Not yet submitted
+**Affects:** Bridge and server
+
+**Problem:**
+Upstream Sigul is intentionally tight-lipped about authentication
+failures (to avoid timing/oracle leaks).  In a containerised
+stack that produces silent end-to-end failures with no
+daemon-side trace to root-cause from.
+
+**Fix:**
+Adds a small `_adbg()` helper and call sites at every auth
+checkpoint on the bridge and server.  The `SIGUL_DEBUG_AUTH`
+environment variable controls output; when unset, behaviour is
+bit-for-bit identical to upstream.
+
+**Impact:**
+
+- With `SIGUL_DEBUG_AUTH=1`: every auth checkpoint emits a
+  human-readable `AUTHDBG/*` log line (peer cert CN, declared
+  user, password-field presence, sha512_password lookup result,
+  crypt(3) compare result).  Log lines carry metadata - no
+  secret values are ever printed.
+- With `SIGUL_DEBUG_AUTH` unset (the default): no logging,
+  no per-request peer-cert lookup, no extra `crypt(3)` calls.
+
+**Code Changes:**
+
+- `bridge.py`: log server/client TCP accepts and post-handshake
+  peer cert CN.
+- `server.py`: log handler dispatch, request fields, and the
+  per-step result of `authenticate_admin`'s password compare.
+- Renames a shadowed local variable (`user` -> `user_row`) in
+  `authenticate_admin` so the log lines are unambiguous.
+
+### 03-fix-delete-key-gpg-home-cleanup.patch
+
+**Status:** CRITICAL - Required for `sigul delete-key` /
+`sigul import-key` round-trip to work.
+**Upstream Status:** Not yet submitted
+**Affects:** Server
+
+**Problem:**
+`server_gpg.Context.delete()` uses the legacy
+`op_delete(key, allow_secret_bool)` API.  In `python-gpg >= 1.23`
+that call is a silent no-op: gpgme deprecated `gpgme_op_delete`,
+the python wrapper does not raise, and the secret/public key
+material stays in the gnupg-home.
+
+Result: `sigul delete-key` removes the row from the server's
+sqlite DB (so `sigul list-keys` no longer reports the key) but
+leaves the underlying GPG key material in place.  A follow-up
+`sigul import-key` for the same fingerprint fails with
+`Error: Invalid import file: Unexpected import file contents`
+because gpg reports the key as already-imported.
+
+**Fix:**
+Switch to `op_delete_ext(key, mode_flags)` with
+`DELETE_ALLOW_SECRET | DELETE_FORCE` flags, the modern API that
+actually deletes.
+
+**Impact:**
+
+- Without this patch: `delete-key` is a half-fix that breaks
+  every later `import-key` for the same fingerprint, and
+  `scripts/run-signing-tests.sh` requires a Phase 0 reset that
+  `rm -rf`'s the server gnupg-home before each run.
+- With this patch: `delete-key` removes the GPG material as
+  expected.  The Phase 0 reset becomes a no-op on a clean stack
+  and can drop in a follow-up cleanup.
+
 ## Applying Patches
 
 The Docker build process automatically applies these patches:

--- a/scripts/run-signing-tests.sh
+++ b/scripts/run-signing-tests.sh
@@ -1051,14 +1051,24 @@ fi
 # ----------------------------------------------------------------------
 testcase "4.4  Negative: ${TEST_USER} CANNOT yet sign with ${NEW_KEY_NAME}"
 
-note "Without grant-key-access the user has no key access record;"
-note "sign-text should be rejected at the auth layer."
+note "Without grant-key-access the user has no KeyAccess row in the"
+note "server DB.  sign-text should be rejected at the auth layer."
+note ""
+note "We deliberately feed SIGUL_TEST_PW_TESTUSER_KEY here - the"
+note "same passphrase test 4.7 will use successfully after the"
+note "grant.  Feeding the user's login password (TESTUSER) instead"
+note "would also fail this test, but for the wrong reason: the"
+note "server's authenticate_user code path checks the supplied"
+note "passphrase against access.encrypted_passphrase, so a wrong"
+note "passphrase always fails regardless of whether the access"
+note "row exists.  Using the right passphrase keeps the test"
+note "unambiguously attributable to the missing access record."
 
 showrun "echo 'pre-grant test message' \\
     > '$(hostpath /work/pre-grant.txt)'"
 
 NEG_OUT=$(
-    printf '%s\0' "$SIGUL_TEST_PW_TESTUSER" \
+    printf '%s\0' "$SIGUL_TEST_PW_TESTUSER_KEY" \
         | docker run --rm -i \
             --user 1000:1000 \
             --network "$NETWORK" \


### PR DESCRIPTION
## Summary

Two related changes:

1. **`patches/03-fix-delete-key-gpg-home-cleanup.patch`** — fixes
   a real Sigul bug discovered while developing the integration
   test suite.
2. **Test 4.4 correctness fix** — addresses Copilot feedback on
   PR #62: feed the per-user key passphrase, not the login
   password, so the negative-test failure is unambiguously
   attributable to the missing KeyAccess row rather than to
   wrong-credential-type rejection.

## Patch 03: `delete-key` actually cleans the gnupg-home

### Problem

`server_gpg.Context.delete(key, delete_secret)` in the Sigul
server uses the legacy `op_delete(key, allow_secret_bool)`
interface.  In `python-gpg >= 1.23` this is a **silent no-op**:
gpgme deprecated the underlying `gpgme_op_delete`, the python
wrapper does not raise, and the secret/public key material stays
in the gnupg-home.

Result: `sigul delete-key` removes the row from the server's
sqlite DB (so `sigul list-keys` no longer reports the key) but
leaves the underlying GPG key material in place.  A follow-up
`sigul import-key` for the same fingerprint fails with:

```text
Error: Invalid import file: Unexpected import file contents
```

because gpg reports the key as already-imported.

### Fix

Switch to `op_delete_ext(key, mode_flags)` with
`DELETE_ALLOW_SECRET | DELETE_FORCE` flags — the modern gpgme API
that actually deletes.

Verified standalone with python-gpg 1.23.2:

```text
ctx.create_key(...)
ctx.op_delete(key, True)        # returns; keylist unchanged
ctx.op_delete_ext(key, 1 | 2)   # returns; keylist now empty
```

After this patch, `scripts/run-signing-tests.sh`'s Phase 0 reset
(which `rm -rf`'s the server gnupg-home as a workaround) becomes
a no-op on a clean stack and can be dropped in a follow-up
cleanup.

Also documents patches 02 and 03 in `patches/README.md` (patch
02 landed without doc updates earlier).

## Test 4.4 fix: address Copilot finding from PR #62

Copilot pointed out that test 4.4 fed `SIGUL_TEST_PW_TESTUSER`
(the user's login password) to a `sign-text` call, expecting
rejection because the user has no `KeyAccess` row yet.  But the
server's `authenticate_user` code path checks the supplied
passphrase against `access.encrypted_passphrase` (with a
`KeyAccess(None, None)` placeholder when no access row exists),
so any wrong passphrase fails regardless of whether the access
row exists.  Feeding the login password effectively tested
"wrong-credential-type rejected" rather than the intended
"no-access-record rejected".

Now feeds `SIGUL_TEST_PW_TESTUSER_KEY` (the same per-user key
passphrase test 4.7 uses successfully after the grant), so the
4.4 failure isolates to the missing `KeyAccess` row.  Multi-line
note in the test explains why this credential choice matters.

## Verification

- All 3 patches still apply cleanly to upstream Sigul v1.4 in
  order; the resulting source parses with `python3 -c "import ast"`.
- `41/41 PASS` locally with the rebuilt server image.
- `actionlint`, `yamllint`, `shellcheck` all clean.

## Risk

Low.

- **Patch 03**: only modifies the `delete()` wrapper; uses gpgme
  flags that have existed since 1.x.  The new behaviour is what
  every caller expected from the legacy method anyway.
- **Test 4.4**: tightens an existing assertion; doesn't change
  the auth code under test.

## Roadmap

| | |
| --- | --- |
| ✅ PR-A | Phase 1 — key lifecycle |
| ✅ PR-B | Phase 2 — text + binary signing |
| ✅ PR-C | Phase 3 — RPM signing |
| ✅ PR-D | Phase 4 — user + key-access lifecycle |
| **This PR** | Sigul patch: fix `delete-key` not cleaning gnupg-home |
| Next | `fedora:41` → `fedora:44` base-image migration |