### PR TITLE
Docs(readme): Address Copilot follow-ups on caching and teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ This repository provides two things:
 
 ## Action usage
 
-The action is a GitHub composite action that builds the Sigul client image on
-the runner (cached across runs) and uses it to sign one or more workspace
-files or a git tag.
+The action is a GitHub composite action that builds the Sigul client image
+on the runner and uses it to sign one or more workspace files or a git
+tag.  The build only reuses an already-present local image, so on
+GitHub-hosted runners (where the Docker daemon is ephemeral) the build
+runs once per workflow run; on self-hosted runners or within a single
+job the image persists between steps.  If you need cross-run caching,
+layer a `docker/build-push-action` step with `cache-from`/`cache-to` of
+type `gha` ahead of the `uses:` line below.
 
 ### Sign a single file
 
@@ -225,9 +230,9 @@ cleans up via a trap on EXIT; nothing is left behind on a successful run.
 ### Tearing the stack down
 
 ```bash
+# Removes all containers, networks and named volumes Compose created
+# from this docker-compose.sigul.yml regardless of project prefix.
 docker compose -f docker-compose.sigul.yml down -v --remove-orphans
-docker volume ls --format '{{.Name}}' | grep '^sigul-docker_' \
-    | xargs -r docker volume rm
 ```
 
 ### Documentation


### PR DESCRIPTION
## Summary

Two follow-up fixes for Copilot review comments left on the merged PR #67.

### 1. Misleading "cached across runs" claim (`README.md#L24`)

The Action-usage paragraph said the client image build is "cached across
runs". The composite action just runs `docker build` and reuses an
already-present local image; on GitHub-hosted runners the Docker daemon is
ephemeral, so there is no cross-run cache without explicit buildx/GHA
caching.

Reworded to describe the actual behaviour — one build per workflow run on
GitHub-hosted runners, persistent within a job, persistent across jobs only
on self-hosted runners — and point at `docker/build-push-action` with
`cache-from`/`cache-to: type=gha` as the way to opt in to cross-run caching.

### 2. Unsafe `grep '^sigul-docker_'` teardown step (`README.md#L230`)

Compose volume names carry the project prefix, which depends on the
directory name and any `-p` flag, so the `grep` could miss the volumes (or,
worse, match an unrelated project that happened to share the prefix).
`docker compose -f docker-compose.sigul.yml down -v --remove-orphans`
already removes every named volume Compose created for this file regardless
of project prefix, so the extra `grep|xargs` step was both redundant and
risky. Dropped it and added a one-line comment explaining why `down -v`
alone suffices.

## Risk

Documentation only. The teardown change makes the documented step strictly
safer; the action-usage rewording is purely descriptive.