### PR TITLE
Chore(docs/action): Contributing section, upstream-patches stance, action.yml input audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,16 @@ failing CI run as the source of truth.
 
 - **Sigul behaviour fixes** — add a numbered patch to
   [`patches/`](./patches/) (`NN-short-description.patch`).  The patch
-  applies on top of upstream Sigul during the image build.  Document
-  every patch in [`patches/README.md`](./patches/README.md) using the
-  same `Status / Affects / Problem / Fix / Impact` structure as the
-  existing entries; if a patch is critical for the stack to start at
-  all, mark it as such.  Verify `git apply --check` works against the
-  bundled Sigul source tree before pushing.
+  applies on top of the bundled Sigul source during the image build.
+  Document every patch in [`patches/README.md`](./patches/README.md)
+  using the same `Status / Affects / Problem / Fix / Impact` structure
+  as the existing entries; if a patch is critical for the stack to
+  start at all, mark it as such.  Verify `git apply --check` works
+  against the bundled Sigul source tree before pushing.  Note that
+  upstream Sigul on Pagure has not had a commit in over a year and
+  Pagure itself is scheduled to be decommissioned around mid-2026, so
+  in practice these patches are a permanent local fork rather than
+  a staging area for upstream submission.
 - **Container build / packaging changes** — prefer
   [`build-scripts/install-sigul.sh`](./build-scripts/install-sigul.sh)
   over editing the Dockerfiles, so the install path stays uniform

--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ type `gha` ahead of the `uses:` line below.
       sign-type: 'sign-data'
       sign-object: ${{ github.workspace }}/artifacts/mypackage.tar.gz
       sigul-key-name: 'my-release-key'
-      sigul-ip: ${{ secrets.SIGUL_IP }}
-      sigul-uri: ${{ secrets.SIGUL_URI }}
       sigul-conf: ${{ secrets.SIGUL_CONF }}
       sigul-pass: ${{ secrets.SIGUL_PASS }}
       sigul-pki: ${{ secrets.SIGUL_PKI }}
@@ -60,8 +58,6 @@ type `gha` ahead of the `uses:` line below.
           artifacts/my-file.jar
           docs/signme.md
       sigul-key-name: 'my-release-key'
-      sigul-ip: ${{ secrets.SIGUL_IP }}
-      sigul-uri: ${{ secrets.SIGUL_URI }}
       sigul-conf: ${{ secrets.SIGUL_CONF }}
       sigul-pass: ${{ secrets.SIGUL_PASS }}
       sigul-pki: ${{ secrets.SIGUL_PKI }}
@@ -80,8 +76,6 @@ type `gha` ahead of the `uses:` line below.
       sigul-key-name: 'my-release-key'
       gh-user: automation-username
       gh-key: ${{ secrets.GITHUB_TOKEN }}
-      sigul-ip: ${{ secrets.SIGUL_IP }}
-      sigul-uri: ${{ secrets.SIGUL_URI }}
       sigul-conf: ${{ secrets.SIGUL_CONF }}
       sigul-pass: ${{ secrets.SIGUL_PASS }}
       sigul-pki: ${{ secrets.SIGUL_PKI }}
@@ -92,15 +86,13 @@ type `gha` ahead of the `uses:` line below.
 | Input | Required | Default | Description |
 | ----- | -------- | ------- | ----------- |
 | `sign-type` | no | `sign-data` | Either `sign-data` or `sign-git-tag`. |
-| `sign-object` | yes | — | File to sign (or newline-separated list of files), or the name of a git tag. |
+| `sign-object` | yes | — | File to sign (or newline-separated list of files), or the name of an annotated git tag. |
 | `sigul-key-name` | yes | — | Name of the key on the Sigul server to sign with. |
-| `sigul-ip` | yes | — | IP address of the Sigul server. Used together with `sigul-uri` to populate `/etc/hosts` inside the action's container. |
-| `sigul-uri` | yes | — | Hostname (URI) of the Sigul server. |
-| `sigul-conf` | yes | — | Sigul client configuration file contents. |
-| `sigul-pass` | yes | — | Passphrase for the Sigul key (key-specific). |
-| `sigul-pki` | yes | — | PKI material for the client, stored as a GPG-armoured file encrypted with `sigul-pass`. |
+| `sigul-conf` | yes | — | Body of the Sigul client configuration file (`client.conf`).  Written verbatim into the container at `client.conf` and used by every `sigul --batch -c client.conf …` invocation, so the bridge hostname / port / NSS settings the client needs all live here. |
+| `sigul-pass` | yes | — | Passphrase for the Sigul key.  Also used as the GPG passphrase to decrypt `sigul-pki`. |
+| `sigul-pki` | yes | — | Client PKI material: a `tar.xz` archive containing a `.sigul/` directory (NSS database, certificates, private key), GPG-encrypted with `sigul-pass`.  May be supplied raw or base64-encoded; the entrypoint auto-detects. |
 | `gh-user` | no | `github.actor` | GitHub user to push the signed tag as (`sign-git-tag` only). |
-| `gh-key` | no | — | GitHub API key for `gh-user`. **Required** for `sign-git-tag`; not used for `sign-data`. |
+| `gh-key` | no | — | GitHub API key for `gh-user`. **Required** for `sign-git-tag`; ignored for `sign-data`. |
 | `sigul-mock-mode` | no | `false` | When `true`, emit deterministic mock signatures locally without contacting a Sigul server. Useful for testing workflow plumbing. |
 
 ### Requirements
@@ -109,9 +101,13 @@ To use the action against a real signing server you need:
 
 - A reachable Sigul server with bridge.
 - A Sigul key whose passphrase matches `sigul-pass`.
-- PKI material (NSS database / certificates) packaged into `sigul-pki`,
-  encrypted using `sigul-pass`.
-- Network connectivity from the GitHub Actions runner to the Sigul bridge.
+- A `client.conf` body for `sigul-conf` that points the client at
+  the right bridge (typically `bridge-hostname` and the matching
+  bridge cert nickname in `[nss]`).
+- A `sigul-pki` archive whose certificates align with the keys and
+  hostnames the bridge expects.
+- Network connectivity from the GitHub Actions runner to the Sigul
+  bridge.
 
 ## Container architecture
 

--- a/README.md
+++ b/README.md
@@ -239,15 +239,101 @@ docker compose -f docker-compose.sigul.yml down -v --remove-orphans
   outside CI.
 - [`OPERATIONS_GUIDE.md`](./OPERATIONS_GUIDE.md) — day-to-day operation,
   monitoring, health checks.
-- [`TESTING.md`](./TESTING.md) — test infrastructure overview and the local
-  ↔ CI parity guarantees the suites enforce.
+- [`TESTING.md`](./TESTING.md) — test infrastructure overview.
 - [`patches/README.md`](./patches/README.md) — what each downstream Sigul
   patch fixes and why.
-- [`docs/`](./docs) — deeper dives on individual subsystems (NSS, container
-  logging, network architecture).
+- [`docs/`](./docs) — deeper dives on individual topics.
 
 ## Contributing
 
-See the patches `README.md` for guidance on how the Sigul source patches are
-structured and applied. New CI changes should land via a pull request to
-`main`; the build/test workflow gates the merge.
+Contributions land through GitHub pull requests against `main`.  The
+`Sigul Build/Test 🐳` workflow is required to pass before a PR can
+merge — it builds all three images for both `linux/amd64` and
+`linux/arm64`, runs the integration test suite, and then runs the full
+end-to-end signing test suite against the resulting stack.  Treat a
+failing CI run as the source of truth.
+
+### Where to make which change
+
+- **Sigul behaviour fixes** — add a numbered patch to
+  [`patches/`](./patches/) (`NN-short-description.patch`).  The patch
+  applies on top of upstream Sigul during the image build.  Document
+  every patch in [`patches/README.md`](./patches/README.md) using the
+  same `Status / Affects / Problem / Fix / Impact` structure as the
+  existing entries; if a patch is critical for the stack to start at
+  all, mark it as such.  Verify `git apply --check` works against the
+  bundled Sigul source tree before pushing.
+- **Container build / packaging changes** — prefer
+  [`build-scripts/install-sigul.sh`](./build-scripts/install-sigul.sh)
+  over editing the Dockerfiles, so the install path stays uniform
+  across `linux/amd64` and `linux/arm64`.  When you do touch a
+  Dockerfile, change all three (`Dockerfile.{client,server,bridge}`)
+  consistently — they share a base image and most of their package
+  set.
+- **Test changes** — the two end-to-end suites are
+  [`scripts/run-integration-tests.sh`](./scripts/run-integration-tests.sh)
+  (control plane: list-users, list-keys, double-TLS handshake, etc.)
+  and
+  [`scripts/run-signing-tests.sh`](./scripts/run-signing-tests.sh)
+  (key lifecycle, sign-text/data/rpm/rpms, user and key-access
+  lifecycle, with each output independently verified by gpg or rpm).
+  New tests should fit into the existing `phase`/`testcase`/`pass`/
+  `fail` shape and remain idempotent against repeated runs.
+- **Workflow / CI changes** — [`build-test.yaml`](./.github/workflows/build-test.yaml)
+  is the only workflow that exercises the stack end-to-end; iterate
+  on it via `workflow_dispatch` with `publish_ghcr: false` until
+  it's green.
+- **Documentation changes** — keep the assertions in this README,
+  `DEPLOYMENT_GUIDE.md`, `OPERATIONS_GUIDE.md` and `TESTING.md`
+  consistent with what the scripts and Dockerfiles actually do.
+  When you delete a script or rename a file, run a `grep -rn` for
+  the old name across the repo and update or drop the dangling
+  references.
+
+### Local verification before pushing
+
+1. Build the three images for your host architecture (see
+   [Bringing up the stack locally](#bringing-up-the-stack-locally)).
+2. Bring the stack up with `scripts/deploy-sigul-infrastructure.sh`.
+3. Run `scripts/run-integration-tests.sh` and
+   `scripts/run-signing-tests.sh`; both should exit `0` with all tests
+   passing.
+4. If you changed the action surface, run a manual
+   `workflow_dispatch` of `Sigul Build/Test 🐳` with
+   `publish_ghcr: false` to confirm both `linux/amd64` and
+   `linux/arm64` legs stay green.
+
+### Commit and PR conventions
+
+- **Conventional Commits**, capitalised types: `Fix(scope):`,
+  `Feat(scope):`, `Docs(scope):`, `Refactor(scope):`,
+  `Test(scope):`, `Chore(scope):`, `CI(scope):`, `Build(scope):`,
+  `Perf(scope):`, `Style(scope):`, `Revert(scope):`.  See
+  [`.gitlint`](./.gitlint) for the enforced set.
+- **Subject ≤ 50 chars, body wrapped at 72** (URL lines exempt).
+- **DCO sign-off required** — every commit must end with
+  `Signed-off-by: Name <email>`; use `git commit -s`.
+- **Atomic commits** — one logical change per commit.  In particular,
+  do not mix code or doc changes with task-tracking updates.
+- **Pre-commit hooks** — the repository ships a
+  [`.pre-commit-config.yaml`](./.pre-commit-config.yaml) that runs
+  ruff, mypy, yamllint, actionlint, reuse (SPDX), codespell,
+  markdownlint, gitlint and a few project-specific validators.
+  Install with `pre-commit install`; never bypass with `--no-verify`.
+  If a hook auto-fixes files, stage the fixes and re-commit — do
+  not `git reset` after a failed commit.
+- **AI-assisted commits** — include a `Co-authored-by:` trailer for
+  the model used (e.g. `Co-authored-by: Claude <claude@anthropic.com>`)
+  immediately above the `Signed-off-by` line.
+- **SPDX headers** — every new source file needs SPDX
+  `Apache-2.0` and copyright headers.  See
+  [`REUSE.toml`](./REUSE.toml) for file-type-specific patterns; the
+  `reuse` pre-commit hook will flag misses.
+
+### Reporting an issue
+
+Use [GitHub Issues](https://github.com/lfreleng-actions/sigul-docker/issues).
+For TLS / NSS / handshake problems include the auth-debug capture
+produced by setting `enable_auth_debug: true` on the
+`workflow_dispatch` form, or by exporting `SIGUL_DEBUG_AUTH=1`
+before running the deploy script locally.

--- a/action.yml
+++ b/action.yml
@@ -13,23 +13,21 @@ inputs:
   sign-object:
     description: "File or git tag to sign"
     required: true
-  sigul-ip:
-    description: "IP address of sigul server"
-    required: true
-  sigul-uri:
-    description: "URI of sigul server"
-    required: true
   sigul-conf:
-    description: "Config file for sigul connection"
+    description: >-
+      Body of the Sigul client configuration file (client.conf)
     required: true
   sigul-key-name:
     description: "The key name on the server to utilize"
     required: true
   sigul-pass:
-    description: "Password for sigul connection"
+    description: "Passphrase for the Sigul key (also used to decrypt sigul-pki)"
     required: true
   sigul-pki:
-    description: "PKI info for sigul connection"
+    description: >-
+      Client PKI material: a tar.xz archive containing the .sigul/
+      directory, GPG-encrypted with sigul-pass.  May be supplied raw or
+      base64-encoded; the entrypoint auto-detects.
     required: true
   gh-user:
     description: "GitHub user for pushing signed tags"
@@ -107,8 +105,6 @@ runs:
         docker run --rm --platform "${PLATFORM}" \
           -e "SIGN_TYPE=${{ inputs.sign-type }}" \
           -e "SIGN_OBJECT=${{ inputs.sign-object }}" \
-          -e "SIGUL_IP=${{ inputs.sigul-ip }}" \
-          -e "SIGUL_URI=${{ inputs.sigul-uri }}" \
           -e "SIGUL_CONF=${{ inputs.sigul-conf }}" \
           -e "SIGUL_KEY_NAME=${{ inputs.sigul-key-name }}" \
           -e "SIGUL_PASS=${{ inputs.sigul-pass }}" \

--- a/patches/README.md
+++ b/patches/README.md
@@ -19,7 +19,7 @@ patches remain minimal and focused on critical functionality.
 ### 01-fix-double-tls-handshake-timing.patch
 
 **Status:** CRITICAL - Required for functionality
-**Upstream Status:** Not yet submitted
+**Upstream Status:** Local fork (upstream Sigul is unmaintained; see below)
 **Affects:** Bridge component
 
 **Problem:**
@@ -47,7 +47,7 @@ double-TLS communication.
 ### 02-verbose-auth-logging.patch
 
 **Status:** Optional - controlled by `SIGUL_DEBUG_AUTH` env var
-**Upstream Status:** Not yet submitted
+**Upstream Status:** Local fork (upstream Sigul is unmaintained; see below)
 **Affects:** Bridge and server
 
 **Problem:**
@@ -85,7 +85,7 @@ bit-for-bit identical to upstream.
 
 **Status:** CRITICAL - Required for `sigul delete-key` /
 `sigul import-key` round-trip to work.
-**Upstream Status:** Not yet submitted
+**Upstream Status:** Local fork (upstream Sigul is unmaintained; see below)
 **Affects:** Server
 
 **Problem:**
@@ -120,7 +120,7 @@ actually deletes.
 ### 04-fix-optional-fedora-client-guard.patch
 
 **Status:** CRITICAL on Fedora 44+ - bridge will not start without it
-**Upstream Status:** Not yet submitted
+**Upstream Status:** Local fork (upstream Sigul is unmaintained; see below)
 **Affects:** Bridge
 
 **Problem:**
@@ -157,7 +157,7 @@ continues normal startup.
 ### 05-fix-optional-rpm-head-signing.patch
 
 **Status:** CRITICAL on Fedora 44+ - server will not start without it
-**Upstream Status:** Not yet submitted
+**Upstream Status:** Local fork (upstream Sigul is unmaintained; see below)
 **Affects:** Server
 
 **Problem:**
@@ -208,49 +208,63 @@ The Docker build process automatically applies these patches:
 3. The script applies all `*.patch` files in alphanumeric order
 4. Sigul is then built and installed with the fixes included
 
-## Upstream Strategy
+## Upstream status
 
-Submit these patches to upstream Sigul (<https://pagure.io/sigul>)
-to benefit the community and reduce our maintenance burden. Once accepted
-upstream, we can remove the patches and use official releases.
+At the time of writing, upstream Sigul on
+[`pagure.io/sigul`](https://pagure.io/sigul) is effectively
+unmaintained:
 
-**Submission Priority:**
+- The most recent commit is the v1.4 release tag, dated roughly a
+  year ago.
+- Open issues and pull requests have been sitting untouched.
+- Pagure itself is scheduled to be decommissioned around mid-2026
+  (Flock 2026); Fedora-hosted projects are being asked to migrate
+  to `forge.fedoraproject.org`.
 
-1. **HIGH:** Double-TLS handshake timing fix (this is critical for containers)
-2. **HIGH:** Fedora-client / rpm-head-signing optional-import
-   guards (patches 04 and 05) - these unbreak Sigul on Fedora
-   44+ base images and are not platform-specific to our stack.
+In practice this means the patches in this directory are a
+**permanent local fork**, not a staging area for upstream
+submission.  We carry them indefinitely, and any new fix should be
+added here rather than waiting on an upstream release.  When
+Pagure goes away we will need to re-host the v1.4 source tarball
+that `build-scripts/install-sigul.sh` clones; the patch series itself
+is self-contained and will continue to apply against any preserved
+copy of v1.4.
 
-## Testing
+## Adding a patch
 
-To verify patches apply cleanly:
+1. **Keep the patch minimal** — one logical change per file; fix the
+   bug, do not refactor surrounding code.
+2. **Use the `NN-short-description.patch` filename convention** so
+   patches apply in a stable order under
+   `build-scripts/install-sigul.sh`.
+3. **Include an explanatory header in the patch file itself** that
+   describes the bug being fixed and why the chosen fix is the
+   right shape; the existing patches use a `# SPDX…` block plus a
+   prose explanation above the `diff --git` lines.
+4. **Add a corresponding entry to this README** under `## Patches`,
+   following the `Status / Affects / Problem / Fix / Impact`
+   structure.  Mark the entry CRITICAL if the stack will not start
+   without it.
+5. **Verify the whole series still applies cleanly:** with the
+   bundled Sigul v1.4 source available locally,
+
+   ```bash
+   cd .build-context/sigul
+   for p in ../../patches/*.patch; do
+       git apply --check "$p" || { echo "$p failed"; break; }
+   done
+   ```
+
+   should print no errors.
+
+## Verifying a single patch in isolation
 
 ```bash
-# Test patch application locally
+# Local copy of upstream v1.4 (or any preserved mirror once Pagure
+# is decommissioned)
 cd /tmp
 git clone --depth 1 --branch v1.4 https://pagure.io/sigul.git
 cd sigul
 patch -p1 < /path/to/sigul-docker/patches/01-fix-double-tls-handshake-timing.patch
-
-# Verify no errors
 echo $?  # Should be 0
 ```
-
-## Contributing
-
-When adding new patches:
-
-1. Keep patches minimal - fix critical issues
-2. Use descriptive filenames with numeric prefixes: `01-`, `02-`, etc.
-3. Include clear comments explaining WHY the fix matters
-4. Test that patches apply cleanly to upstream Sigul v1.4
-5. Plan for upstream submission
-
-## Maintenance
-
-When upstream Sigul releases new versions:
-
-1. Test if patches still apply cleanly
-2. Update patches if necessary
-3. Remove patches that upstream accepts
-4. Update `build-scripts/install-sigul.sh` if using newer version


### PR DESCRIPTION
## Summary

Three related cleanups stacked together:

1. **`README.md` Contributing section** — replace the two-sentence stub
   with a substantive guide covering where to make different kinds of
   change (patches/, install-sigul.sh vs Dockerfiles, the two test
   suites, build-test.yaml, docs), the minimum local-verification
   path, the project's commit and PR conventions (Conventional
   Commits, gitlint enforcement, DCO sign-off, atomic commits,
   pre-commit hooks, AI co-authorship, SPDX), and how to file an
   issue.

2. **`patches/README.md` upstream stance** — the previous "Upstream
   Strategy" / "Contributing" / "Maintenance" sections framed
   `patches/` as a staging area for upstream submission. That has
   not been realistic for some time:

   - The last commit on `pagure.io/sigul` is the v1.4 release tag,
     dated roughly a year ago.
   - Open issues and PRs sit untouched.
   - Pagure itself is scheduled to be decommissioned around mid-2026
     (Flock 2026); Fedora-hosted projects are being moved to
     `forge.fedoraproject.org`.

   Replace with an "Upstream status" section that states the
   situation, plus a concrete "Adding a patch" workflow. Also
   replace `**Upstream Status:** Not yet submitted` on every patch
   entry with `Local fork (upstream Sigul is unmaintained; see
   below)` so the per-patch Status line tells the truth.

3. **`action.yml` input audit** — cross-checked every input against
   `entrypoint.sh` and the rest of the tree. Two findings:

   - **`sigul-ip` and `sigul-uri` were dead.** Both were declared
     `required: true` and passed into the container as `SIGUL_IP` /
     `SIGUL_URI`, but nothing in `entrypoint.sh` ever read them.
     The README went further and claimed they were used to populate
     `/etc/hosts`; no `/etc/hosts` manipulation happens anywhere.
     Since the action has only ever been consumed inside this
     repository, there are no external callers to preserve
     compatibility for. Removed both inputs from `action.yml` and
     the corresponding `-e` lines from the docker-run wrapper, and
     dropped them from the README input table and every workflow
     snippet.
   - **Three remaining input descriptions were terse to the point
     of being misleading.** Updated `action.yml` and the matching
     README cells:
     - `sigul-conf` is the literal body of `client.conf`, written
       verbatim into the container; the bridge hostname / port /
       NSS settings come exclusively from this blob (which is also
       why `sigul-ip` and `sigul-uri` could be dead).
     - `sigul-pass` doubles as the GPG passphrase for `sigul-pki`,
       not just the signing-key passphrase.
     - `sigul-pki` is specifically a `tar.xz` archive of a `.sigul/`
       directory (NSS database, certificates, private key),
       GPG-encrypted with `sigul-pass`; the entrypoint accepts
       either raw or base64-encoded blobs and auto-detects.

   Workflow-snippet examples now show only the inputs that actually
   matter for each `sign-type`. The Requirements section now lists
   the actual prerequisites (`client.conf` body that points at the
   right bridge, PKI archive whose certs align with that bridge).

## Risk

Documentation only for items 1 and 2.

For item 3, removing `sigul-ip` / `sigul-uri` is a breaking change
to the action input surface — but per the user, the action has only
ever been called from inside this repository, and there are no
in-repo callsites that pass either input. `entrypoint.sh` and the
`docker run` wrapper are otherwise unchanged; no behaviour changes
beyond the unused-input removal.

## Stacked context

Stacked on top of the merged #66 / #67 / #68 / #69 / #70.
Independent of any other open PR.