### PR TITLE
Docs(readme): Add Troubleshooting section, trim Reporting an issue

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,19 +14,16 @@ on:
         default: false
         required: false
       enable_auth_debug:
+        # Sets SIGUL_DEBUG_AUTH=1 for the integration test stack
+        # Surfaces AUTHDBG/* lines in container logs
         description: >-
           Enable verbose auth/handshake logging in bridge & server
-          (sets SIGUL_DEBUG_AUTH=1 for the integration test stack;
-          surfaces AUTHDBG/* lines in container logs)
         type: boolean
         default: false
         required: false
       publish_ghcr:
         description: >-
-          Publish the freshly-built images to the GitHub Container
-          Registry (ghcr.io).  Untick to skip publishing - useful
-          when iterating on the workflow itself or running a quick
-          test build that should not change the published images.
+          Publish images to the GitHub Container Registry
         type: boolean
         default: true
         required: false

--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ failing CI run as the source of truth.
 ### Reporting an issue
 
 Use [GitHub Issues](https://github.com/lfreleng-actions/sigul-docker/issues) to report problems and bugs.
+
 A good report includes the steps to reproduce, what you expected to
 happen versus what actually happened, the relevant container or
 workflow logs, and — for stack-level bugs — the diagnostic bundle

--- a/README.md
+++ b/README.md
@@ -240,6 +240,27 @@ docker compose -f docker-compose.sigul.yml down -v --remove-orphans
   patch fixes and why.
 - [`docs/`](./docs) — deeper dives on individual topics.
 
+## Troubleshooting
+
+- **TLS / NSS / handshake errors** (`Unexpected EOF in NSPR`,
+  silent timeouts, opaque auth failures): set `SIGUL_DEBUG_AUTH=1`
+  locally, or `enable_auth_debug: true` on the
+  `workflow_dispatch` form in CI, to surface `AUTHDBG/*` lines in
+  the bridge / server logs (added by patch 02).  Then run
+  `./scripts/debug-tls-stack.sh --all --verbose`.  See
+  [`docs/TLS_DEBUGGING_GUIDE.md`](./docs/TLS_DEBUGGING_GUIDE.md)
+  and [`docs/DEBUGGING_QUICK_REFERENCE.md`](./docs/DEBUGGING_QUICK_REFERENCE.md)
+  for the full walk-through.
+- **Stack won't come up cleanly:** run the
+  `scripts/validate-{volumes,nss,certificates,configs}.sh`
+  helpers; each supports `--help` and is safe to run in any order.
+- **Capturing a bundle to attach to an issue:**
+  `./scripts/collect-sigul-diagnostics.sh --compress` produces a
+  redacted tarball under `diagnostics/`.
+- **Last resort:** stale volumes are the most common cause of
+  "impossible" stack bugs.  `docker compose -f docker-compose.sigul.yml
+  down -v --remove-orphans` and redeploy.
+
 ## Contributing
 
 Contributions land through GitHub pull requests against `main`.  The
@@ -332,8 +353,9 @@ failing CI run as the source of truth.
 
 ### Reporting an issue
 
-Use [GitHub Issues](https://github.com/lfreleng-actions/sigul-docker/issues).
-For TLS / NSS / handshake problems include the auth-debug capture
-produced by setting `enable_auth_debug: true` on the
-`workflow_dispatch` form, or by exporting `SIGUL_DEBUG_AUTH=1`
-before running the deploy script locally.
+Use [GitHub Issues](https://github.com/lfreleng-actions/sigul-docker/issues) to report problems and bugs.
+A good report includes the steps to reproduce, what you expected to
+happen versus what actually happened, the relevant container or
+workflow logs, and — for stack-level bugs — the diagnostic bundle
+from `scripts/collect-sigul-diagnostics.sh --compress` (see
+[Troubleshooting](#troubleshooting)).


### PR DESCRIPTION
## Summary

The README's `Reporting an issue` subsection had two distinct
concerns mixed together: how to file a bug report, and how to debug
a TLS / NSS / handshake failure. The auth-debug capture guidance is
troubleshooting advice, not issue-reporting etiquette.

This PR:

1. **Adds a `## Troubleshooting` section** as a top-level heading
   between `### Documentation` and `## Contributing`. Four bullets,
   each pointing at a real script and (where appropriate) the
   longer-form doc:

   - TLS / NSS / handshake errors → `SIGUL_DEBUG_AUTH=1` or
     `enable_auth_debug: true` to surface `AUTHDBG/*` lines, plus
     `scripts/debug-tls-stack.sh --all --verbose`. Pointer at
     `docs/TLS_DEBUGGING_GUIDE.md` and
     `docs/DEBUGGING_QUICK_REFERENCE.md`.
   - Stack won't come up cleanly → the
     `validate-{volumes,nss,certificates,configs}.sh` helpers.
   - Capturing a diagnostic bundle →
     `scripts/collect-sigul-diagnostics.sh --compress`.
   - Last resort → `docker compose down -v --remove-orphans` and
     redeploy.

2. **Trims `### Reporting an issue`** back to what it should
   actually say: GitHub Issues link, plus what a useful bug report
   contains (reproducer, expected vs actual, logs, diagnostic
   bundle for stack-level bugs — with a pointer at the new
   Troubleshooting section for how to produce the bundle).

## Risk

Documentation only.