### PR TITLE
Chore: Sweep validated Copilot feedback from merged PRs

### DIFF
--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -25,6 +25,11 @@ permissions: {}
 jobs:
   openssf-scorecard:
     name: "OpenSSF Scorecard"
+    # NOTE: GitHub Actions does not allow `timeout-minutes` on jobs
+    # that call a reusable workflow via `uses:`.  The reusable
+    # workflow defines its own per-job timeouts.  The repository's
+    # `Check GitHub Workflows set timeout-minutes` pre-commit hook
+    # therefore correctly skips this job.
     # yamllint disable-line rule:line-length
     uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@2f4f1db634cdecc9af63d7946cb6b818ce590484  # v0.3.3
     permissions:

--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ deliverables live in this repository:
 The action is a GitHub composite action that builds the Sigul client image
 on the runner and uses it to sign one or more workspace files or a git
 tag.  The build only reuses an already-present local image, so on
-GitHub-hosted runners (where the Docker daemon is ephemeral) the build
-runs once per workflow run; on self-hosted runners or within a single
-job the image persists between steps.  If you need cross-run caching,
-layer a `docker/build-push-action` step with `cache-from`/`cache-to` of
-type `gha` ahead of the `uses:` line below.
+GitHub-hosted runners (where the Docker daemon is per-job) the build
+runs once per job; on self-hosted runners the image persists across
+jobs that share the same daemon.  If you need cross-run caching, run a
+`docker/build-push-action` step with `cache-from` / `cache-to: type=gha`
+*and* tag the loaded image as either
+`client-${PLATFORM_ID}-image:${PLATFORM_ID}` or
+`client-${PLATFORM_ID}-image:action` ahead of the `uses:` line below —
+those are the tags this action's build step looks for before deciding
+to skip its own `docker build`.
 
 ### Sign a single file
 
@@ -88,7 +92,7 @@ type `gha` ahead of the `uses:` line below.
 | `sign-type` | no | `sign-data` | Either `sign-data` or `sign-git-tag`. |
 | `sign-object` | yes | — | File to sign (or newline-separated list of files), or the name of an annotated git tag. |
 | `sigul-key-name` | yes | — | Name of the key on the Sigul server to sign with. |
-| `sigul-conf` | yes | — | Body of the Sigul client configuration file (`client.conf`).  Written verbatim into the container at `client.conf` and used by every `sigul --batch -c client.conf …` invocation, so the bridge hostname / port / NSS settings the client needs all live here. |
+| `sigul-conf` | yes | — | Body of the Sigul client configuration file. The action's entrypoint writes it to `client.conf` inside the container's Sigul config directory (`/var/sigul/config`, falling back to `/etc/sigul` or `$HOME/.sigul-config`) and passes the resulting path to every `sigul --batch -c …` invocation. The bridge hostname / port / NSS settings the client needs all live here. |
 | `sigul-pass` | yes | — | Passphrase for the Sigul key.  Also used as the GPG passphrase to decrypt `sigul-pki`. |
 | `sigul-pki` | yes | — | Client PKI material: a `tar.xz` archive containing a `.sigul/` directory (NSS database, certificates, private key), GPG-encrypted with `sigul-pass`.  May be supplied raw or base64-encoded; the entrypoint auto-detects. |
 | `gh-user` | no | `github.actor` | GitHub user to push the signed tag as (`sign-git-tag` only). |

--- a/build-scripts/install-sigul.sh
+++ b/build-scripts/install-sigul.sh
@@ -64,13 +64,13 @@ install_from_source() {
         log_info "Copied local sigul source"
     else
         # CI/Production: Always use official public Sigul repository.
-        # Pinned to the v1.4 release tag because the patches in
-        # patches/ are written against that tree (see
+        # Pinned to the SIGUL_VERSION release tag because the patches
+        # in patches/ are written against that tree (see
         # patches/README.md).
         log_info "Cloning sigul from official upstream repository (Pagure)"
 
         local sigul_repo="https://pagure.io/sigul.git"
-        local sigul_branch="v1.4"
+        local sigul_branch="v${SIGUL_VERSION}"
 
         log_info "Repository: $sigul_repo"
         log_info "Branch / tag: $sigul_branch"
@@ -78,7 +78,7 @@ install_from_source() {
         if ! git clone --depth 1 --branch "$sigul_branch" "$sigul_repo" sigul; then
             log_error "Failed to clone sigul from official upstream repository"
             log_error "Repository: $sigul_repo"
-            log_error "Branch: $sigul_branch"
+            log_error "Branch / tag: $sigul_branch"
             return 1
         fi
 

--- a/build-scripts/install-sigul.sh
+++ b/build-scripts/install-sigul.sh
@@ -63,14 +63,17 @@ install_from_source() {
         cp -r /build-context/sigul ./sigul
         log_info "Copied local sigul source"
     else
-        # CI/Production: Always use official public Sigul repository
+        # CI/Production: Always use official public Sigul repository.
+        # Pinned to the v1.4 release tag because the patches in
+        # patches/ are written against that tree (see
+        # patches/README.md).
         log_info "Cloning sigul from official upstream repository (Pagure)"
 
         local sigul_repo="https://pagure.io/sigul.git"
-        local sigul_branch="master"
+        local sigul_branch="v1.4"
 
         log_info "Repository: $sigul_repo"
-        log_info "Branch: $sigul_branch"
+        log_info "Branch / tag: $sigul_branch"
 
         if ! git clone --depth 1 --branch "$sigul_branch" "$sigul_repo" sigul; then
             log_error "Failed to clone sigul from official upstream repository"

--- a/scripts/run-signing-tests.sh
+++ b/scripts/run-signing-tests.sh
@@ -242,21 +242,26 @@ _sigul_emit() {
     #     ... <volume mounts> ... <client-image> bash -c '...'`
     #     wrapper is omitted because logging it on every line
     #     would drown out the interesting Sigul commands.
-    #   * The trailing rc-capture / chmod-fixup / `exit \$rc`
-    #     housekeeping that the real exec uses is shown as
-    #     `chmod ... /work` rather than the literal find pipeline
-    #     - the housekeeping is a CI-permission workaround, not
-    #     part of what the sigul command is doing.
+    #   * The trailing `rc=\$?; find /work ... -exec chmod ...;
+    #     exit \$rc` housekeeping that the real exec uses is
+    #     omitted from the printed payload entirely - it's a
+    #     CI-permission workaround, not part of what the sigul
+    #     command is doing, and including it would make a
+    #     copy-pasted line fail because of the shell-quoting
+    #     and find-pipeline syntax.  The find pipeline is
+    #     visible in the source below this printf if you need
+    #     to see the exact form.
     #
     # To reproduce a printed line, take the in-container payload
-    # and substitute it into the docker-run wrapper template that
+    # (just the `umask 0022; <cmd>` portion shown below) and
+    # substitute it into the docker-run wrapper template that
     # the script's startup banner emits as a `[note]` block
     # immediately after the title banner.  That template is
     # generated from the same `CLIENT_IMAGE`, `NETWORK`, volume
     # variables, and `--user 1000:1000` flag that this helper
     # uses, so the wrapper matches the real exec exactly.
     printf '%b$ printf %q | %s%b\n' "${C_YELLOW}" \
-        "$printed_stdin" "umask 0022; ${cmd}; chmod ... /work" \
+        "$printed_stdin" "umask 0022; ${cmd}" \
         "${C_RESET}" >&2
 
     # shellcheck disable=SC2059
@@ -361,15 +366,26 @@ note "Client config volume: ${CLIENT_CONFIG_VOLUME}"
 note "Admin password loaded from test-artifacts/admin-password"
 note ""
 note "Reproducer wrapper for printed sigul-client invocations:"
+# Render the wrapper template with shell-escaped substitutions (via
+# printf %q) so a path containing whitespace or shell metacharacters
+# would still produce a copy-pasteable command, matching what the
+# real `docker run` invocation tolerates.
+_REPRO_NETWORK=$(printf '%q' "${NETWORK}")
+_REPRO_NSS=$(printf '%q' "${CLIENT_NSS_VOLUME}")
+_REPRO_CFG=$(printf '%q' "${CLIENT_CONFIG_VOLUME}")
+_REPRO_WORK=$(printf '%q' "${HOST_WORKDIR}")
+_REPRO_FIX=$(printf '%q' "${FIXTURES_DIR}")
+_REPRO_IMG=$(printf '%q' "${CLIENT_IMAGE}")
 note "  printf '<passphrase>\\0' | docker run --rm -i \\"
 note "    --user 1000:1000 \\"
-note "    --network ${NETWORK} \\"
-note "    -v ${CLIENT_NSS_VOLUME}:/etc/pki/sigul/client:ro \\"
-note "    -v ${CLIENT_CONFIG_VOLUME}:/etc/sigul:ro \\"
-note "    -v ${HOST_WORKDIR}:/work:rw \\"
-note "    -v ${FIXTURES_DIR}:/fixtures:ro \\"
-note "    ${CLIENT_IMAGE} \\"
+note "    --network ${_REPRO_NETWORK} \\"
+note "    -v ${_REPRO_NSS}:/etc/pki/sigul/client:ro \\"
+note "    -v ${_REPRO_CFG}:/etc/sigul:ro \\"
+note "    -v ${_REPRO_WORK}:/work:rw \\"
+note "    -v ${_REPRO_FIX}:/fixtures:ro \\"
+note "    ${_REPRO_IMG} \\"
 note "    bash -c '<paste in-container command here>'"
+unset _REPRO_NETWORK _REPRO_NSS _REPRO_CFG _REPRO_WORK _REPRO_FIX _REPRO_IMG
 
 # ----------------------------------------------------------------------
 # PHASE 0: Reset state for idempotent reruns


### PR DESCRIPTION
## Summary

Audit pass over Copilot review threads left on merged PRs (#60–#74).
Most findings are already addressed elsewhere or are obsolete; this
PR addresses the five that are still valid:

| Source | File | Finding | Verdict |
| --- | --- | --- | --- |
| #66 | `scripts/run-signing-tests.sh` | Printed payload's `chmod ... /work` placeholder is not a real command — copy-paste fails | **Fix:** drop the placeholder from the printed payload; comment block above the `printf` already explains the elided housekeeping |
| #66 | `scripts/run-signing-tests.sh` | `Reproducer wrapper` `[note]` block doesn't shell-escape interpolated paths/values | **Fix:** render each value through `printf %q` before substituting |
| #70 | `README.md` | "Once per workflow run" is imprecise — Docker daemon is per-*job* on hosted runners | **Fix:** correct to "per-job", and clarify the across-jobs-only-on-self-hosted distinction |
| #70 | `README.md` | Cross-run caching guidance underspecified — doesn't say which tag the composite-action build step looks for | **Fix:** spell out the `client-${PLATFORM_ID}-image:${PLATFORM_ID}` / `:action` tag handshake |
| #71 | `README.md` | `sigul-conf` description claims the config is written "verbatim into the container at `client.conf`"; actually `entrypoint.sh` writes to `/var/sigul/config/client.conf` (or fallback paths) | **Fix:** correct the description |
| #71 | `build-scripts/install-sigul.sh` | `patches/README` says re-host the v1.4 tarball, but the install script clones `master` | **Fix:** pin clone to `v1.4` (matches what `patches/` expects) |
| #72 | `.github/workflows/openssf-scorecard.yaml` | "Add `timeout-minutes`" suggestion | **Not actionable** — GitHub Actions rejects `timeout-minutes` on jobs that `uses:` a reusable workflow. Added an explanatory comment to the workflow so the next reader doesn't repeat the experiment. |

## Already addressed elsewhere (no-ops in this PR)

- **#61** — `rm -rf -- {}` in `sync-local-sigul.sh` and the
  "robust to any byte sequence" wording. Both already resolved.
- **#62** — `SIGUL_TEST_PW_TESTUSER` vs `TESTUSER_KEY` in test 4.4.
  Already resolved.
- **#64** — "can drop" grammar in `patches/README`. Already fixed
  during the patches/README rewrite.
- **#69** — `tests/integration/test_sigul_stack.py` `compose_project`
  hard-coding. File deleted in #74.

## Verification

`prek run --all-files` clean: basedpyright, actionlint, yamllint,
check-github-workflows, write-good, codespell, reuse, markdownlint
all green.

## Risk

Low. Documentation, log-output cosmetics, and one upstream-source
pin-tag change. The `install-sigul.sh` v1.4 pin is the only
behavioural change; before this PR it was cloning whatever happens
to be on `master`, which is currently the v1.4 tag commit anyway,
so containers built before vs after this PR install the same
source tree.