### PR TITLE
CI(release): Run tag-validate in parallel with repository-metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,10 +74,9 @@ jobs:
           artifact_upload: 'true'
           artifact_formats: 'json'
 
-  ### Step 1: Validate the pushed tag ###
+  ### Step 1: Validate the pushed tag (parallel with repository-metadata) ###
   tag-validate:
     name: 'Validate Tag'
-    needs: [repository-metadata]
     runs-on: 'ubuntu-24.04'
     permissions:
       contents: read
@@ -110,7 +109,10 @@ jobs:
   ### Step 2: Build all three images for both architectures ###
   build-containers:
     name: 'Build: ${{ matrix.component }} (${{ matrix.platform }})'
-    needs: [tag-validate]
+    # Wait for both prelude jobs - repository-metadata and
+    # tag-validate run in parallel, but no expensive build runs
+    # unless both pass.
+    needs: [repository-metadata, tag-validate]
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

`release.yaml`'s prelude was previously serial:

```text
repository-metadata -> tag-validate -> build-containers -> ... -> promote-release
```

The two prelude jobs are independent — `repository-metadata` only gathers
GitHub metadata, `tag-validate` only checks the pushed tag's semver
shape and signature — so they don't need to be sequenced.

This PR runs them in parallel:

```text
repository-metadata ─┐
                     ├-> build-containers -> ... -> promote-release
tag-validate ────────┘
```

`build-containers` now has `needs: [repository-metadata, tag-validate]`
so the expensive build still won't start unless **both** prelude jobs
pass — any prelude failure aborts the release before the matrix builds
allocate runners.

## Risk

Negligible. Same set of jobs, same gating semantics for the expensive
work; the only change is the wall-clock wait between two cheap jobs.