### PR TITLE
Fix(release): Add missing client setup step before integration tests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -265,6 +265,86 @@ jobs:
           SIGUL_RUNNER_PLATFORM: ${{ steps.platform.outputs.id }}
         run: ./scripts/deploy-sigul-infrastructure.sh
 
+      # yamllint disable rule:line-length
+      - name: 'Setup client for integration tests'
+        shell: bash
+        env:
+          SIGUL_CLIENT_IMAGE: 'client-${{ steps.platform.outputs.id }}-image:test'
+        run: |
+          set -euo pipefail
+          echo '🔧 Setting up client container for integration tests...'
+
+          NETWORK_NAME=$(docker network ls --filter "name=sigul" \
+            --format "{{.Name}}" | head -1)
+          echo "Using network: ${NETWORK_NAME}"
+
+          docker volume create sigul-docker_sigul_client_nss || true
+          docker volume create sigul-docker_sigul_client_config || true
+
+          docker run --rm \
+            -v sigul-docker_sigul_client_nss:/target-nss \
+            -v sigul-docker_sigul_client_config:/target-config \
+            alpine:3.19 \
+            sh -c 'chown -R 1000:1000 /target-nss /target-config'
+
+          BRIDGE_NSS_VOLUME=$(docker volume ls --format "{{.Name}}" \
+            | grep -E "bridge.*nss|sigul.*bridge.*nss" | head -1)
+          echo "Bridge NSS volume: ${BRIDGE_NSS_VOLUME}"
+
+          NSS_PASSWORD=$(cat test-artifacts/nss-password)
+
+          docker run -d --name sigul-client-init \
+            --network "${NETWORK_NAME}" \
+            --user sigul \
+            -v "${BRIDGE_NSS_VOLUME}":/etc/pki/sigul/bridge:ro \
+            -v sigul-docker_sigul_client_nss:/etc/pki/sigul/client:rw \
+            -v sigul-docker_sigul_client_config:/etc/sigul:rw \
+            -e NSS_PASSWORD="${NSS_PASSWORD}" \
+            "${SIGUL_CLIENT_IMAGE}" \
+            tail -f /dev/null
+
+          sleep 3
+
+          echo "Initializing client certificates..."
+          docker exec sigul-client-init /usr/local/bin/init-client-certs.sh
+
+          docker exec --user root sigul-client-init bash -c \
+            'cat > /etc/sigul/client.conf << "EOFCONFIG"
+          [client]
+          bridge-hostname: sigul-bridge.example.org
+          bridge-port: 44334
+          server-hostname: sigul-server.example.org
+          # Default identity for batch-mode requests.  Without this,
+          # sigul falls back to getpass.getuser() inside the client
+          # container - that resolves to the sigul user, which is not
+          # the admin user we created in the server database, so
+          # every request would fail AUTHENTICATION_FAILED.
+          user-name: admin
+
+          [gnupg]
+          gnupg-bin: /usr/bin/gpg2
+          gnupg-key-type: RSA
+          gnupg-key-length: 4096
+
+          [nss]
+          client-cert-nickname: sigul-client-cert
+          nss-ca-cert-nickname: sigul-ca
+          nss-bridge-cert-nickname: sigul-bridge-cert
+          nss-dir: /etc/pki/sigul/client
+          nss-password: '"${NSS_PASSWORD}"'
+          nss-min-tls: tls1.2
+          EOFCONFIG
+          '
+
+          docker exec --user root sigul-client-init \
+            chown sigul:sigul /etc/sigul/client.conf
+
+          docker stop sigul-client-init
+          docker rm sigul-client-init
+
+          echo "✅ Client setup complete"
+      # yamllint enable rule:line-length
+
       - name: 'Run integration tests'
         shell: bash
         env:


### PR DESCRIPTION
## Summary

The first real tag-triggered release run (v0.1.0,
[run 25500199841](https://github.com/modeseven-lfreleng-actions/sigul-docker/actions/runs/25500199841))
failed in the `functional-tests` job with:

```text
[nss] nss-dir '/var/sigul/.sigul' is not a directory
```

repeated for every sigul-client invocation in
`scripts/run-integration-tests.sh`. 7/10 tests failed; the 3 that
"passed" are the ones that don't actually exercise the client (e.g.
`user-info` resolves server-side and doesn't need client certs).

## Root cause

`build-test.yaml`'s `functional-tests` job has a 90-line `Setup client
for integration tests` block between **Deploy Sigul stack** and **Run
integration tests** that:

- Creates the `sigul_client_nss` / `sigul_client_config` volumes and
  chowns them to UID 1000.
- Runs a temporary client-init container, execs
  `init-client-certs.sh` inside it (copies the bridge CA + client
  cert/key into the NSS DB), and writes the client.conf with
  `[client] user-name: admin`, `[nss] nss-dir: /etc/pki/sigul/client`
  etc.
- Tears the init container down.

`release.yaml` was missing this step entirely. With no client setup,
the client container had no NSS database, no client.conf, and no
`user-name` override — so the sigul binary fell back to its default
`nss-dir: /var/sigul/.sigul`, which doesn't exist, and every test
that needed an authenticated client connection failed.

## Fix

Insert the identical client-setup block into `release.yaml`'s
`functional-tests` job at the right point in the sequence. The block
is copy-equivalent to `build-test.yaml`'s, so the release path now
exercises the same client setup that PR validation runs against.

## Risk

Low. Pure addition of a step that the parallel workflow already runs
without issue. The `prek` suite is clean.

## Note for the failed v0.1.0 tag

The v0.1.0 tag's release workflow ran 7 jobs and failed at functional
tests. With this fix merged, options are:

1. Cut a new tag (e.g. `v0.1.1`) — the cleanest path; v0.1.0 is left
   as a "release that didn't ship".
2. Re-run the failed jobs on the existing run — only works if GitHub
   Actions still allows individual-job rerun on the workflow given
   how long has passed.

Suggest option 1 unless there's a strong reason to keep v0.1.0.