### PR TITLE
Chore(workflows): Rename matrix display 'Functional Tests' to 'Tests'

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -344,7 +344,7 @@ jobs:
 
   ### Functional Tests ###
   functional-tests:
-    name: 'Functional Tests: ${{ matrix.platform }}'
+    name: 'Tests: ${{ matrix.platform }}'
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -190,7 +190,7 @@ jobs:
 
   ### Step 3: Functional tests against the freshly-built stack ###
   functional-tests:
-    name: 'Functional Tests: ${{ matrix.platform }}'
+    name: 'Tests: ${{ matrix.platform }}'
     needs: [build-containers]
     runs-on: ${{ matrix.runner }}
     permissions:


### PR DESCRIPTION
## Summary

Shorter display in the GitHub Actions UI. Both `build-test.yaml` and
`release.yaml` had a matrix job named `Functional Tests: linux/amd64`
/ `...arm64`; rename to `Tests: linux/amd64` / `...arm64`.

Internal job ID `functional-tests:` kept as-is, along with the section
comment headers and step names. This is a UI rename only — two lines
changed.

## Risk

None — `name:` is purely cosmetic, no `needs:` or job ID dependencies
touched.