### PR TITLE
CI(release): Drop unused repository-metadata dep from summary job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -561,8 +561,12 @@ jobs:
   ### Step 6: Final summary ###
   summary:
     name: 'Release Summary'
+    # repository-metadata intentionally not listed: the summary
+    # script does not reference its result, and promote-release
+    # transitively requires tag-validate which runs in parallel
+    # with repository-metadata, so summary already runs after both
+    # prelude jobs in practice.
     needs:
-      - repository-metadata
       - tag-validate
       - build-containers
       - functional-tests


### PR DESCRIPTION
## Summary

The release summary script reports `tag-validate`, `build-containers`,
`functional-tests`, `publish-ghcr`, and `promote-release` results — not
`repository-metadata`. Listing `repository-metadata` in the summary
job's `needs:` was a stale carry-over.

Drop it.

## Behaviour

Unchanged in practice. `promote-release` transitively requires
`tag-validate`, which runs in parallel with `repository-metadata` since
#77, so summary already runs after both prelude jobs. The change just
cleans up the declared dependency to match what the summary script
actually uses.

## `build-test.yaml`

Checked — already correct. Its `Deploy Summary` job's `needs:` is
`[build-containers, publish-ghcr, functional-tests]`, with no
`repository-metadata`. No parallel change needed there.

## Risk

None. Cosmetic dependency-graph cleanup.