### PR TITLE
Feat(ci): Add SBOM and Grype scan to PR builds

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -342,6 +342,232 @@ jobs:
         run: docker manifest inspect "${IMAGE}:${TAG}"
       # yamllint enable rule:line-length
 
+  ### PR SBOM + vulnerability scan ###
+  #
+  # Mirrors release.yaml's sign-attest-scan job for PR / dispatch
+  # runs, stripped of the registry-bound supply-chain steps (cosign
+  # signing, attest-build-provenance, attest-sbom). The remaining
+  # steps -- SBOM generation, Grype scan, SARIF upload, artifact
+  # upload -- operate purely against the locally-loaded image and
+  # need no registry credentials. AMD64 only: Anchore's SBOM action
+  # against a multi-arch manifest scans the host-platform variant,
+  # so the release workflow effectively scans amd64 too. Scanning
+  # both arches on PR would double runtime for marginal additional
+  # CVE coverage (CVEs at the OS-package layer are nearly always
+  # arch-agnostic).
+  pr-sbom-scan:
+    name: 'SBOM + Scan: ${{ matrix.component }}'
+    needs: [build-containers]
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: read
+      # github/codeql-action/upload-sarif publishes Grype findings
+      # to the repository's code-scanning alerts. On PRs from forks
+      # this scope is silently downgraded to read; the upload step
+      # is wrapped in continue-on-error so the scan still produces
+      # the downloadable SARIF artifact in that case.
+      security-events: write
+    timeout-minutes: 15
+    strategy:
+      # Don't short-circuit other components if one's Grype scan
+      # finds CVEs at the configured threshold; we want SBOMs and
+      # SARIF for every component in a single PR run.
+      fail-fast: false
+      matrix:
+        component: ['client', 'server', 'bridge']
+    env:
+      # 'low' matches release.yaml so PR feedback and release
+      # gating use the same severity bar. Set the
+      # NO_BLOCK_AUDIT_FAIL repository variable to 'true' to
+      # soft-fail when a transitive CVE in a third-party
+      # dependency is unavoidable; the SARIF and step-summary
+      # report still publishes.
+      GRYPE_FAIL_ON: 'low'
+    steps:
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'audit'
+
+      - name: 'Download AMD64 image artifact'
+        # yamllint disable-line rule:line-length
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: ${{ matrix.component }}-linux-amd64-image
+          path: /tmp
+
+      - name: 'Load image into Docker'
+        shell: bash
+        env:
+          COMPONENT: ${{ matrix.component }}
+        run: |
+          set -euo pipefail
+          docker load --input "/tmp/${COMPONENT}-linux-amd64.tar"
+          docker images "${COMPONENT}:linux-amd64"
+
+      - name: 'Generate SPDX SBOM'
+        # yamllint disable-line rule:line-length
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
+        with:
+          image: ${{ matrix.component }}:linux-amd64
+          format: spdx-json
+          output-file: sbom-${{ matrix.component }}.spdx.json
+          # The SBOM action's own artifact upload duplicates the
+          # explicit upload-artifact step below; disabling it
+          # keeps all assets under one consistent naming pattern.
+          upload-artifact: false
+
+      - name: 'Install Grype'
+        id: grype
+        # yamllint disable-line rule:line-length
+        uses: anchore/scan-action/download-grype@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2  # v7.4.0
+        with:
+          cache-db: 'true'
+
+      - name: 'Grype scan SBOM'
+        id: grype-scan
+        env:
+          GRYPE_CMD: ${{ steps.grype.outputs.cmd }}
+          COMPONENT: ${{ matrix.component }}
+          FAIL_ON: ${{ env.GRYPE_FAIL_ON }}
+          NO_BLOCK_AUDIT_FAIL: >-
+            ${{ vars.NO_BLOCK_AUDIT_FAIL == 'true' }}
+        run: |
+          set +e
+          "${GRYPE_CMD}" \
+            -o "sarif=grype-${COMPONENT}.sarif" \
+            -o "json=grype-${COMPONENT}.json" \
+            -o "table=grype-${COMPONENT}.txt" \
+            --fail-on "${FAIL_ON}" \
+            "sbom:sbom-${COMPONENT}.spdx.json"
+          grype_exit=$?
+          set -e
+
+          echo "--- Grype scan results (${COMPONENT}) ---"
+          if [[ -f "grype-${COMPONENT}.txt" ]]; then
+            cat "grype-${COMPONENT}.txt"
+          else
+            echo "No table output produced"
+          fi
+
+          # Grype exits 2 when matches at/above --fail-on were
+          # found. Any other non-zero exit means grype itself
+          # failed and we must surface that.
+          if [[ "${grype_exit}" == "0" ]]; then
+            echo "No vulnerabilities at or above '${FAIL_ON}'"
+            exit 0
+          fi
+          if [[ "${grype_exit}" != "2" ]]; then
+            echo "::error::Grype exited with code ${grype_exit}"
+            exit "${grype_exit}"
+          fi
+
+          if [[ "${NO_BLOCK_AUDIT_FAIL}" == "true" ]]; then
+            echo "::warning::${COMPONENT}: Grype found findings" \
+              "at or above '${FAIL_ON}', but NO_BLOCK_AUDIT_FAIL" \
+              "is set so the PR check will pass."
+            exit 0
+          fi
+          echo "::error::${COMPONENT}: Grype found vulnerabilities" \
+            "at or above '${FAIL_ON}'. See the table above."
+          exit 1
+
+      - name: 'Upload Grype SARIF to code scanning'
+        if: always()
+        # continue-on-error: PRs from forks have security-events
+        # downgraded to read-only, in which case this step would
+        # otherwise fail the matrix entry even on a successful
+        # scan. The SARIF file is still attached to the workflow
+        # run as an artifact below for reviewer inspection.
+        continue-on-error: true
+        # yamllint disable-line rule:line-length
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
+        with:
+          sarif_file: grype-${{ matrix.component }}.sarif
+          # Distinct category from release.yaml's 'grype-<component>'
+          # so PR-time findings are tracked separately from the
+          # main-branch / released-image alert stream.
+          category: pr-grype-${{ matrix.component }}
+
+      - name: 'Upload SBOM and Grype reports as workflow artifact'
+        if: always()
+        # yamllint disable-line rule:line-length
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: pr-sbom-and-scan-${{ matrix.component }}
+          path: |
+            sbom-${{ matrix.component }}.spdx.json
+            grype-${{ matrix.component }}.sarif
+            grype-${{ matrix.component }}.json
+            grype-${{ matrix.component }}.txt
+          # Shorter retention than the release workflow's 90 days:
+          # PR-run reports are review-time signal, not a release
+          # record.
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: 'Grype Markdown summary'
+        if: always()
+        env:
+          COMPONENT: ${{ matrix.component }}
+        run: |
+          # Render a Markdown table of Grype matches into the job
+          # step summary so reviewers see findings without leaving
+          # the workflow run. CVE data is sourced from the JSON
+          # output (jq-parsed so multi-word cells cannot break the
+          # table column layout).
+          json_file="grype-${COMPONENT}.json"
+          {
+            echo "## Grype scan: ${COMPONENT}"
+            echo ""
+            if [[ ! -f "${json_file}" ]]; then
+              echo "No scan results available."
+              exit 0
+            fi
+            match_count=$(jq '.matches | length' "${json_file}")
+            if [[ "${match_count}" == "0" ]]; then
+              echo "No vulnerabilities at or above the configured" \
+                "severity threshold."
+              exit 0
+            fi
+            echo "Found ${match_count} Grype record(s)."
+            echo ""
+            echo "| Package | Installed | Fixed In | Type |" \
+              "Vulnerability | Severity | EPSS | Risk |"
+            echo "| --- | --- | --- | --- | --- | --- | --- | --- |"
+            jq -r '
+              def esc: tostring | gsub("\\|"; "\\|");
+              def round2: (. * 100 | round) / 100;
+              def epss_pct:
+                ( .vulnerability.epss // [] ) as $e
+                | if ($e | length) == 0 then "-"
+                  else ( $e[0].epss // 0 ) as $p
+                    | if $p == 0 then "0%"
+                      elif ($p * 100) < 0.01 then "<0.01%"
+                      else ( ($p * 100) | round2 | tostring
+                             + "%" ) end
+                  end;
+              def risk_fmt:
+                .vulnerability.risk
+                | if . == null then "-"
+                  elif type == "number" then
+                    (round2 | tostring)
+                  else (. | tostring) end;
+              .matches[] |
+              [ (.artifact.name // "-" | esc),
+                (.artifact.version // "-" | esc),
+                ( ( .vulnerability.fix.versions // [] )
+                  | if length == 0 then "-"
+                    else join(", ") end | esc ),
+                (.artifact.type // "-" | esc),
+                (.vulnerability.id // "-" | esc),
+                (.vulnerability.severity // "-" | esc),
+                epss_pct,
+                risk_fmt
+              ] | "| " + join(" | ") + " |"
+            ' "${json_file}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   ### Functional Tests ###
   functional-tests:
     name: 'Tests: ${{ matrix.platform }}'
@@ -866,6 +1092,7 @@ jobs:
     needs: [
       build-containers,
       publish-ghcr,
+      pr-sbom-scan,
       functional-tests
     ]
     if: always()
@@ -884,6 +1111,8 @@ jobs:
             echo "|-----|--------|"
             echo "| Build (matrix: amd64 + arm64) |" \
               " ${{ needs.build-containers.result }} |"
+            echo "| SBOM + Grype (matrix: 3 components) |" \
+              " ${{ needs.pr-sbom-scan.result }} |"
             echo "| Functional Tests (matrix: amd64 + arm64) |" \
               " ${{ needs.functional-tests.result }} |"
             echo ""
@@ -898,6 +1127,18 @@ jobs:
             echo "### Functional Tests"
             echo "- **Status**: ${{ needs.functional-tests.result }}"
             echo "- **Includes**: Integration testing against fresh infrastructure"
+            echo ""
+
+            echo "### Supply-chain scan"
+            echo "- **Status**: ${{ needs.pr-sbom-scan.result }}"
+            echo "- **Includes**: SPDX SBOM (anchore/sbom-action)" \
+              "and Grype vulnerability scan per component image"
+            echo "- **Artifacts**: pr-sbom-and-scan-COMPONENT per" \
+              "component (SPDX JSON + Grype SARIF/JSON/TXT," \
+              "14-day retention)"
+            echo "- **Code scanning**: SARIF uploaded under category" \
+              "pr-grype-COMPONENT for same-repo PRs; fork PRs fall" \
+              "back to the workflow-run artifacts above"
             echo ""
 
             echo "### GHCR Publishing"


### PR DESCRIPTION
## Summary

Ports the release pipeline's supply-chain visibility steps to
PR-time builds. A new `pr-sbom-scan` matrix job runs after
`build-containers`, mirroring `release.yaml`'s `sign-attest-scan`
but stripped of registry-bound steps (no signing, no
attestations, no release-asset attachment — those have no
meaning for an in-flight PR).

## What it adds

For each component (`client`, `server`, `bridge`), the new job:

- Downloads the AMD64 image tarball produced by
  `build-containers` and loads it locally via `docker load`.
- `anchore/sbom-action` → SPDX-JSON SBOM against the loaded
  image.
- `anchore/scan-action/download-grype` with `cache-db: true`.
- Grype scan of the SBOM with `--fail-on low` — same threshold
  as `release.yaml`, honouring the same `NO_BLOCK_AUDIT_FAIL`
  repository variable as a soft-fail escape hatch.
- `github/codeql-action/upload-sarif` to publish findings to
  code scanning under category `pr-grype-<component>` (distinct
  from `release.yaml`'s `grype-<component>` so PR alerts are
  tracked separately from the main-branch / released-image
  alert stream). Wrapped in `continue-on-error: true` so fork
  PRs — where `security-events` is silently downgraded to
  read-only — still produce the downloadable artifact.
- `actions/upload-artifact` of SBOM + Grype SARIF / JSON / TXT
  as `pr-sbom-and-scan-<component>` (14-day retention; shorter
  than release's 90 because PR reports are review-time signal,
  not a release record).
- Per-component Markdown CVE table in `$GITHUB_STEP_SUMMARY` so
  reviewers see findings without leaving the workflow run.

The `summary` job's `needs` list and step body are extended to
include the new job, so the deploy summary now shows a single
**Supply-chain scan** section alongside Build and Functional
Tests.

## Design choices

| Choice | Rationale |
|---|---|
| **AMD64 only** | `anchore/sbom-action` against the release workflow's multi-arch manifest scans the host-platform variant (amd64 on `ubuntu-latest`), so the release effectively scans amd64 too. Adding ARM64 on PR would double runtime for marginal CVE coverage at the OS-package layer. |
| **`--fail-on low`** | Matches `release.yaml`. PR feedback and release gating use the same severity bar — a release-blocking CVE shouldn't first surface on tag push. |
| **Distinct SARIF category** | `pr-grype-<component>` vs `grype-<component>` keeps PR-time noise out of the main-branch alert stream. |
| **`continue-on-error` on SARIF upload** | Fork PRs lack the `security-events: write` permission. The scan still produces the artifact in that case. |
| **14-day artifact retention** | PR reports are review-time signal, not a release record. |
| **`fail-fast: false`** | A noisy component shouldn't deny SBOMs/SARIF for the others. |

## Explicitly NOT ported

- `cosign sign` — PRs publish nothing, so a signature has no
  immutable digest to bind to.
- `attest-build-provenance` and `attest-sbom` — same reason;
  both attach OCI referrers to a pushed manifest.
- Release-asset attachment and the verification footer — no
  release exists for an in-flight PR.

## Verification

- `yamllint` clean (only the two pre-existing `comments-indentation`
  warnings from the project's `### Section ###` convention — no
  new violations introduced).
- `actionlint` clean.
- Pre-commit suite passes (REUSE, yamllint, actionlint, workflow
  validators, etc.).
- Not yet validated end-to-end against a real PR run — that
  validation happens when this PR itself runs the workflow.
  Individual building blocks (anchore + grype + SARIF upload)
  are the same ones already merged in `release.yaml`.

🤖 Co-authored by Claude (Anthropic) under
@ModeSevenIndustrialSolutions's direction.
