### PR TITLE
Fix(security): Address valid OpenSSF Scorecard findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,17 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 15
+
+  # Keep the digest pin on the fedora:44 base image in each
+  # Dockerfile in sync with the upstream tag. Without this,
+  # pinning the base image by sha256 (for OpenSSF Scorecard's
+  # Pinned-Dependencies check) would silently rot.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Build(images)"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -38,10 +38,13 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+# Workflow-level permissions are intentionally minimal. Each job
+# below declares the extra scopes it needs (e.g. publish-ghcr adds
+# `packages: write`, build-containers adds `actions: write` for cache
+# deletion), which keeps the GITHUB_TOKEN tightly scoped per job and
+# satisfies the OpenSSF Scorecard `Token-Permissions` check.
 permissions:
   contents: read
-  packages: write
-  actions: write  # Required for cache deletion when clear_cache is true
 
 env:
   REGISTRY: ghcr.io

--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Simplified Dockerfile for sigul bridge using dedicated build scripts
-FROM fedora:44
+# Base image is pinned by digest in addition to tag so a tag
+# re-point cannot silently change the base layer (OpenSSF Scorecard
+# Pinned-Dependencies). Dependabot's docker ecosystem keeps the
+# digest in sync with the upstream fedora:44 tag.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 LABEL org.opencontainers.image.title="Sigul Bridge"

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Unified Dockerfile for sigul client using the new cert-init approach
-FROM fedora:44
+# Base image is pinned by digest in addition to tag so a tag
+# re-point cannot silently change the base layer (OpenSSF Scorecard
+# Pinned-Dependencies). Dependabot's docker ecosystem keeps the
+# digest in sync with the upstream fedora:44 tag.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 LABEL org.opencontainers.image.title="Sigul Client"

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,7 +2,11 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Simplified Dockerfile for sigul server using dedicated build scripts
-FROM fedora:44
+# Base image is pinned by digest in addition to tag so a tag
+# re-point cannot silently change the base layer (OpenSSF Scorecard
+# Pinned-Dependencies). Dependabot's docker ecosystem keeps the
+# digest in sync with the upstream fedora:44 tag.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 LABEL org.opencontainers.image.title="Sigul Server"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,77 @@
+<!--
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+-->
+
+# Security Policy
+
+This document describes the security policy for this repository, including
+which versions receive security updates and how to report vulnerabilities.
+
+## Supported Versions
+
+Maintainers develop and merge security fixes on the default branch
+(`main`) and publish those fixes in the latest tagged release. Older
+releases and tags do not receive security updates. Users should track
+the latest tagged release for security patches.
+
+| Version               | Supported          |
+| --------------------- | ------------------ |
+| Latest tagged release | :white_check_mark: |
+| Older releases/tags   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it
+**privately** so that maintainers can investigate and release a fix before
+the issue becomes publicly known.
+
+### Preferred: GitHub Private Vulnerability Reporting
+
+Use GitHub's private vulnerability reporting feature:
+
+1. Navigate to the **Security** tab of this repository.
+2. Click **Report a vulnerability**.
+3. Provide as much detail as possible (see below).
+
+This creates a private advisory visible to maintainers.
+
+### Alternative: Email
+
+If you cannot use GitHub's private reporting, send an email to the Linux
+Foundation Release Engineering team at:
+
+- **<releng@linuxfoundation.org>**
+
+Please do **not** report security vulnerabilities through public GitHub
+issues, discussions, or pull requests.
+
+### What to Include
+
+To help maintainers triage and resolve the report, please include:
+
+- A clear description of the vulnerability and its potential impact.
+- Steps to reproduce the issue (proof-of-concept code or commands).
+- The affected version(s), commit SHA, or release tag.
+- Any known mitigations or workarounds.
+- Your name and contact details for follow-up (optional).
+
+## Response Process
+
+Maintainers will acknowledge receipt of vulnerability reports within
+**5 business days**. We aim to:
+
+1. Confirm the vulnerability and determine its severity.
+2. Develop and test a fix in a private branch or advisory.
+3. Coordinate a disclosure timeline with the reporter.
+4. Release a patched version and publish a security advisory.
+
+We follow a responsible disclosure process and credit reporters in the
+published advisory unless they request to remain anonymous.
+
+## Scope
+
+This policy covers the source code, configuration, and documentation
+in this repository. Please report vulnerabilities in upstream
+dependencies to their respective maintainers; this project will update
+affected dependencies once fixes become available.


### PR DESCRIPTION
## Summary

Triage of the 28 open OpenSSF Scorecard code-scanning alerts on this repository. This PR applies the repo-content fixes for the items that evaluated as valid; the remaining alerts will be dismissed via the code-scanning API with the rationale captured below.

## Content fixes in this PR

| Alert(s) | Rule | Fix |
|----------|------|-----|
| #30 | Security-Policy | Add `SECURITY.md` (copied verbatim from the `actions-template` repo) |
| #7, #8 | Token-Permissions | Tighten `build-test.yaml` top-level `permissions:` to `contents: read` only. Every job already declares the extra scopes it needs, so the previous top-level `packages: write` / `actions: write` grants were strictly wider than necessary |
| #9, #10, #11 | Pinned-Dependencies | Pin `fedora:44` by `sha256` digest in `Dockerfile.bridge`, `Dockerfile.client`, `Dockerfile.server` |
| (supporting) | — | Add a `docker` `package-ecosystem` to `.github/dependabot.yml` so the new digest pin stays in sync with the upstream `fedora:44` tag |

The digest used (`sha256:6c75d5bf...3b898`) was resolved from `docker.io/library/fedora:44` at the time of this commit.

## Alerts dismissed (not addressed by repo content)

| Alert(s) | Rule | Rationale |
|----------|------|-----------|
| #1 | Branch-Protection | Repository settings — out of scope for this content-only round |
| #25 | Code-Review | Historical PR-review data; cannot be fixed retroactively in repo content (addressed by branch protection going forward) |
| #26 | CII-Best-Practices | External badge — not a repo content fix |
| #28 | Fuzzing | Not applicable to a Docker build/sign image stack |
| #29 | SAST | Repo content is Dockerfiles + shell with a single small Python file; Grype already runs against every PR for vulnerability scanning |
| #2 | Token-Permissions (`build-test.yaml:89`) | `actions: write` on `build-containers` is required for the `clear_cache` cache deletion path |
| #3 | Token-Permissions (`clear-action-cache.yaml:50`) | `actions: write` is the whole purpose of the job (deletes cache entries) |
| #4 | Token-Permissions (`openssf-scorecard.yaml:39`) | `security-events: write` is required to upload SARIF |
| #5 | Token-Permissions (`release-drafter.yaml:24`) | `contents: write` is required to create the draft release |
| #31 | Token-Permissions (`release.yaml:1110`) | `contents: write` is required to promote the draft release |
| #32 | Token-Permissions (`release.yaml:939`) | `contents: write` is required to attach SBOM / scan assets to the draft release |
| #12–#19, #42–#44 | Pinned-Dependencies (pip) | These are ad-hoc upgrades (`pip>=26.1`, `idna>=3.15`, `SQLAlchemy==1.3.24`, `passlib`, `python-nss-ng`) inside Dockerfile/script RUN steps. Converting to `pip install --require-hashes` would require pre-computed hash files per pin and would block the legitimate `>=` upgrade semantics used to patch unfixed Fedora packages. PyPI is already accessed over HTTPS and the resulting images are SBOM'd and Grype-scanned on every PR and release |

## Validation

- `pre-commit run` against all touched files: all hooks pass (yamllint, markdownlint, actionlint, reuse, codespell, write-good, GitHub workflow validators).
- Commit is GPG-signed and DCO-signed off using the local Git identity.

## Follow-up

Once this PR merges I will dismiss the alerts listed above through the code-scanning API with the rationale recorded here.