### PR TITLE
Fix: Derive image.source label from workflow context

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -192,6 +192,15 @@ jobs:
           # publishing.
           tags: |
             ${{ matrix.component }}:${{ steps.platform.outputs.id }}
+          # OCI labels derived from the workflow context so they stay
+          # correct regardless of which org/repo this is published
+          # from (survives the planned move to lfreleng-actions and
+          # any forks). Static component-specific labels (image.title
+          # / image.description) remain in the Dockerfiles.
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           outputs: |
             type=docker,dest=/tmp/${{ matrix.component }}-${{ steps.platform.outputs.id }}.tar
           push: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -187,6 +187,15 @@ jobs:
           platforms: ${{ matrix.runner == 'ubuntu-24.04-arm' && '' || matrix.platform }}
           tags: |
             ${{ matrix.component }}:${{ steps.platform.outputs.id }}
+          # OCI labels derived from the workflow context so they stay
+          # correct regardless of which org/repo this is published
+          # from (survives the planned move to lfreleng-actions and
+          # any forks). Static component-specific labels (image.title
+          # / image.description) remain in the Dockerfiles.
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.url=https://github.com/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
           outputs: |
             type=docker,dest=/tmp/${{ matrix.component }}-${{ steps.platform.outputs.id }}.tar
           push: false

--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -7,7 +7,6 @@ FROM fedora:44
 LABEL maintainer="releng@linuxfoundation.org"
 LABEL org.opencontainers.image.title="Sigul Bridge"
 LABEL org.opencontainers.image.description="Simplified Linux Foundation signing infrastructure bridge"
-LABEL org.opencontainers.image.source="https://github.com/lfreleng-actions/sigul-docker"
 
 # Update package manager
 RUN dnf update -y && \

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -7,7 +7,6 @@ FROM fedora:44
 LABEL maintainer="releng@linuxfoundation.org"
 LABEL org.opencontainers.image.title="Sigul Client"
 LABEL org.opencontainers.image.description="Unified Linux Foundation signing infrastructure client"
-LABEL org.opencontainers.image.source="https://github.com/lfreleng-actions/sigul-docker"
 
 # Update package manager
 RUN dnf update -y && \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -7,7 +7,6 @@ FROM fedora:44
 LABEL maintainer="releng@linuxfoundation.org"
 LABEL org.opencontainers.image.title="Sigul Server"
 LABEL org.opencontainers.image.description="Simplified Linux Foundation signing infrastructure server"
-LABEL org.opencontainers.image.source="https://github.com/lfreleng-actions/sigul-docker"
 
 # Update package manager
 RUN dnf update -y && \


### PR DESCRIPTION
## What

Replaces the hardcoded `org.opencontainers.image.source` LABEL in the three Dockerfiles with a value derived from the workflow context, so it stays correct regardless of which org / repo the image is published from. Survives the planned move to `lfreleng-actions` and any forks with no further code changes.

## Why the static value was wrong

The Dockerfiles previously carried:

```dockerfile
LABEL org.opencontainers.image.source="https://github.com/lfreleng-actions/sigul-docker"
```

Wrong on two counts:
- Wrong path — missing `-sign-`.
- Wrong owner — `lfreleng-actions/sigul-sign-docker` does not exist (404 today).

A static fix would have to be re-applied after the planned move to `lfreleng-actions`, and would still be wrong in any fork.

## Approach

- **Remove** the static `image.source` LABEL from each of `Dockerfile.bridge`, `Dockerfile.client`, `Dockerfile.server`. Keep the static component-specific labels (`image.title` / `image.description`) — those don't depend on the repo location.
- **Add** a `labels:` block to both `docker/build-push-action` steps (`build-test.yaml`, `release.yaml`) so each build bakes in:

  ```
  org.opencontainers.image.source   = https://github.com/${{ github.repository }}
  org.opencontainers.image.url      = https://github.com/${{ github.repository }}
  org.opencontainers.image.revision = ${{ github.sha }}
  ```

The image is built once with `push: false`, exported to a tar artifact, then loaded and pushed by `publish-ghcr`. Labels baked in at build time survive the tar export/load cycle, so **no changes are needed to `publish-ghcr` itself**.

## Effect

GHCR uses `image.source` to auto-link a container package to its source repository, which drives the package-page "Source" link, inheritance of repository collaborator permissions, and SLSA / provenance tooling resolving the canonical source URL. With the dynamic label:

- Today: auto-links to `modeseven-lfreleng-actions/sigul-sign-docker` ✅
- After the move: auto-links to `lfreleng-actions/sigul-sign-docker` ✅ — no code change needed
- In any fork: auto-links to the fork ✅

Already-published packages are unaffected by this PR alone — the label only takes effect on the next publish.

## Files changed

| File | Change |
|---|---|
| `Dockerfile.bridge` | Remove 1 line — static `image.source` LABEL |
| `Dockerfile.client` | Remove 1 line — static `image.source` LABEL |
| `Dockerfile.server` | Remove 1 line — static `image.source` LABEL |
| `.github/workflows/build-test.yaml` | Add `labels:` block to the `docker/build-push-action` step |
| `.github/workflows/release.yaml` | Add `labels:` block to the `docker/build-push-action` step |

## Follow-up (out of scope here)

`docker/metadata-action` would generate the full standard set of OCI labels (including `image.created`, `image.licenses`, `image.version`) and a unified tag-generation strategy. Worth doing as a separate refactor; not needed to fix the source-label problem this PR addresses.

## Local validation

`prek run --files` against all five changed files: **all hooks passed** (`yamllint`, `actionlint`, `hadolint`, `reuse lint`, `codespell`, GitHub Actions Workflow Linter, timeout-minutes check, etc.).