### PR TITLE
Docs: Prepare README and ops docs for the repo move

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
       - id: markdownlint
         args: ["--fix"]
         exclude:
-          "^(docs/|DEPLOYMENT_GUIDE\\.md|OPERATIONS_GUIDE\\.md|README\\.md|baseline-paths\\.md)"
+          "^(docs/|OPERATIONS_GUIDE\\.md|baseline-paths\\.md)"
 
   - repo: https://github.com/fsfe/reuse-tool
     rev: 9fabf9eb815a57aac116b435e8346c200cdb8604  # frozen: v6.2.0

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -14,11 +14,15 @@ container) on a host with Docker. The same flow is used in CI by
 
 The stack is three containers built from `fedora:44`:
 
-| Component | Image | Listens on |
-| --------- | ----- | ---------- |
-| Server | `server-<platform>-image:test` | (no incoming TCP; connects out to the bridge on port 44333) |
-| Bridge | `bridge-<platform>-image:test` | TCP/44333 (server side), TCP/44334 (client side); always binds `0.0.0.0` |
-| Client | `client-<platform>-image:test` | (run on demand by the action and test scripts) |
+<!-- markdownlint-disable MD013 -->
+
+| Component | Image                          | Listens on                                                               |
+| --------- | ------------------------------ | ------------------------------------------------------------------------ |
+| Server    | `server-<platform>-image:test` | (no incoming TCP; connects out to the bridge on port 44333)              |
+| Bridge    | `bridge-<platform>-image:test` | TCP/44333 (server side), TCP/44334 (client side); always binds `0.0.0.0` |
+| Client    | `client-<platform>-image:test` | (run on demand by the action and test scripts)                           |
+
+<!-- markdownlint-enable MD013 -->
 
 `<platform>` is `linux-amd64` or `linux-arm64`. The CI workflow builds and
 publishes both. For local development you typically build only the platform
@@ -105,14 +109,18 @@ The repository ships several validation scripts under
 [`scripts/`](./scripts) that sanity-check different aspects of the
 deployment:
 
-| Script | What it checks |
-| ------ | -------------- |
-| `validate-nss.sh` | NSS database files exist, have the right ownership, and contain the expected certificate nicknames. |
-| `validate-certificates.sh` | Certificates are valid, not expired, and correctly chain to the CA. |
-| `validate-configs.sh` | Bridge / server / client configs parse and reference matching FQDNs. |
-| `validate-volumes.sh` | Required Docker volumes exist with the correct ownership. |
-| `verify-cert-hostname-alignment.sh` | Bridge / server certificate CNs match the hostnames the configs use. |
-| `verify-network.sh` / `verify-dns.sh` | Inter-container connectivity and name resolution. |
+<!-- markdownlint-disable MD013 -->
+
+| Script                                | What it checks                                                                                      |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `validate-nss.sh`                     | NSS database files exist, have the right ownership, and contain the expected certificate nicknames. |
+| `validate-certificates.sh`            | Certificates are valid, not expired, and correctly chain to the CA.                                 |
+| `validate-configs.sh`                 | Bridge / server / client configs parse and reference matching FQDNs.                                |
+| `validate-volumes.sh`                 | Required Docker volumes exist with the correct ownership.                                           |
+| `verify-cert-hostname-alignment.sh`   | Bridge / server certificate CNs match the hostnames the configs use.                                |
+| `verify-network.sh` / `verify-dns.sh` | Inter-container connectivity and name resolution.                                                   |
+
+<!-- markdownlint-enable MD013 -->
 
 Each script supports `--help`.
 

--- a/OPERATIONS_GUIDE.md
+++ b/OPERATIONS_GUIDE.md
@@ -651,7 +651,7 @@ For critical issues:
 1. **Check documentation**: NETWORK_ARCHITECTURE.md, DEPLOYMENT_GUIDE.md,
    OPERATIONS_GUIDE.md, TESTING.md
 2. **Run diagnostics**: `./scripts/collect-sigul-diagnostics.sh`
-3. **GitHub Issues**: <https://github.com/lfreleng-actions/sigul-docker/issues>
+3. **GitHub Issues**: <https://github.com/lfreleng-actions/sigul-sign-docker/issues>
 4. **Run validation suites**: `./scripts/validate-certificates.sh`,
    `./scripts/validate-configs.sh`, `./scripts/validate-nss.sh`,
    `./scripts/validate-volumes.sh`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,25 @@ SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # 🔏 Sigul Signing
 
+<!-- markdownlint-disable MD013 -->
+
+[![Linux Foundation](https://img.shields.io/badge/Linux-Foundation-blue)](https://linuxfoundation.org/)
+[![Source Code](https://img.shields.io/badge/GitHub-Source-blue?logo=github&logoColor=white)](https://github.com/lfreleng-actions/sigul-sign-docker)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![REUSE status](https://api.reuse.software/badge/github.com/lfreleng-actions/sigul-sign-docker)](https://api.reuse.software/info/github.com/lfreleng-actions/sigul-sign-docker)
+[![Latest Release](https://img.shields.io/github/v/release/lfreleng-actions/sigul-sign-docker?label=Release&include_prereleases&sort=semver)](https://github.com/lfreleng-actions/sigul-sign-docker/releases)
+
+[![Build & Test](https://github.com/lfreleng-actions/sigul-sign-docker/actions/workflows/build-test.yaml/badge.svg?branch=main)](https://github.com/lfreleng-actions/sigul-sign-docker/actions/workflows/build-test.yaml)
+[![pre-commit.ci status badge]][pre-commit.ci results page]
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/lfreleng-actions/sigul-sign-docker/badge)](https://scorecard.dev/viewer/?uri=github.com/lfreleng-actions/sigul-sign-docker)
+[![Zizmor Scan](https://github.com/lfreleng-actions/sigul-sign-docker/actions/workflows/zizmor.yaml/badge.svg?branch=main)](https://github.com/lfreleng-actions/sigul-sign-docker/actions/workflows/zizmor.yaml)
+
+[![Client Image](https://img.shields.io/badge/ghcr.io-client-blue?logo=docker&logoColor=white)](https://github.com/lfreleng-actions/sigul-sign-docker/pkgs/container/sigul-sign-docker%2Fclient)
+[![Server Image](https://img.shields.io/badge/ghcr.io-server-blue?logo=docker&logoColor=white)](https://github.com/lfreleng-actions/sigul-sign-docker/pkgs/container/sigul-sign-docker%2Fserver)
+[![Bridge Image](https://img.shields.io/badge/ghcr.io-bridge-blue?logo=docker&logoColor=white)](https://github.com/lfreleng-actions/sigul-sign-docker/pkgs/container/sigul-sign-docker%2Fbridge)
+
+<!-- markdownlint-enable MD013 -->
+
 A GitHub Action and supporting Docker stack for signing build artefacts and
 git tags using a [Sigul](https://pagure.io/sigul) signing server.  Two
 deliverables live in this repository:
@@ -35,7 +54,7 @@ to skip its own `docker build`.
 ### Sign a single file
 
 ```yaml
-- uses: lfreleng-actions/sigul-docker@v1
+- uses: lfreleng-actions/sigul-sign-docker@v1
   with:
       sign-type: 'sign-data'
       sign-object: ${{ github.workspace }}/artifacts/mypackage.tar.gz
@@ -54,7 +73,7 @@ to skip its own `docker build`.
 ### Sign multiple files in a single invocation
 
 ```yaml
-- uses: lfreleng-actions/sigul-docker@v1
+- uses: lfreleng-actions/sigul-sign-docker@v1
   with:
       sign-type: 'sign-data'
       sign-object: |
@@ -73,7 +92,7 @@ to skip its own `docker build`.
 ### Sign a git tag
 
 ```yaml
-- uses: lfreleng-actions/sigul-docker@v1
+- uses: lfreleng-actions/sigul-sign-docker@v1
   with:
       sign-type: 'sign-git-tag'
       sign-object: 'v1.1' # Existing unsigned annotated tag in the repo
@@ -87,17 +106,21 @@ to skip its own `docker build`.
 
 ## Action inputs
 
-| Input | Required | Default | Description |
-| ----- | -------- | ------- | ----------- |
-| `sign-type` | no | `sign-data` | Either `sign-data` or `sign-git-tag`. |
-| `sign-object` | yes | — | File to sign (or newline-separated list of files), or the name of an annotated git tag. |
-| `sigul-key-name` | yes | — | Name of the key on the Sigul server to sign with. |
-| `sigul-conf` | yes | — | Body of the Sigul client configuration file. The action's entrypoint writes it to `client.conf` inside the container's Sigul config directory (`/var/sigul/config`, falling back to `/etc/sigul` or `$HOME/.sigul-config`) and passes the resulting path to every `sigul --batch -c …` invocation. The bridge hostname / port / NSS settings the client needs all live here. |
-| `sigul-pass` | yes | — | Passphrase for the Sigul key.  Also used as the GPG passphrase to decrypt `sigul-pki`. |
-| `sigul-pki` | yes | — | Client PKI material: a `tar.xz` archive containing a `.sigul/` directory (NSS database, certificates, private key), GPG-encrypted with `sigul-pass`.  May be supplied raw or base64-encoded; the entrypoint auto-detects. |
-| `gh-user` | no | `github.actor` | GitHub user to push the signed tag as (`sign-git-tag` only). |
-| `gh-key` | no | — | GitHub API key for `gh-user`. **Required** for `sign-git-tag`; ignored for `sign-data`. |
-| `sigul-mock-mode` | no | `false` | When `true`, emit deterministic mock signatures locally without contacting a Sigul server. Useful for testing workflow plumbing. |
+<!-- markdownlint-disable MD013 -->
+
+| Input             | Required | Default        | Description                                                                                                                                                                                                                                                                                                                                                                  |
+| ----------------- | -------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `sign-type`       | no       | `sign-data`    | Either `sign-data` or `sign-git-tag`.                                                                                                                                                                                                                                                                                                                                        |
+| `sign-object`     | yes      | —              | File to sign (or newline-separated list of files), or the name of an annotated git tag.                                                                                                                                                                                                                                                                                      |
+| `sigul-key-name`  | yes      | —              | Name of the key on the Sigul server to sign with.                                                                                                                                                                                                                                                                                                                            |
+| `sigul-conf`      | yes      | —              | Body of the Sigul client configuration file. The action's entrypoint writes it to `client.conf` inside the container's Sigul config directory (`/var/sigul/config`, falling back to `/etc/sigul` or `$HOME/.sigul-config`) and passes the resulting path to every `sigul --batch -c …` invocation. The bridge hostname / port / NSS settings the client needs all live here. |
+| `sigul-pass`      | yes      | —              | Passphrase for the Sigul key.  Also used as the GPG passphrase to decrypt `sigul-pki`.                                                                                                                                                                                                                                                                                       |
+| `sigul-pki`       | yes      | —              | Client PKI material: a `tar.xz` archive containing a `.sigul/` directory (NSS database, certificates, private key), GPG-encrypted with `sigul-pass`.  May be supplied raw or base64-encoded; the entrypoint auto-detects.                                                                                                                                                    |
+| `gh-user`         | no       | `github.actor` | GitHub user to push the signed tag as (`sign-git-tag` only).                                                                                                                                                                                                                                                                                                                 |
+| `gh-key`          | no       | —              | GitHub API key for `gh-user`. **Required** for `sign-git-tag`; ignored for `sign-data`.                                                                                                                                                                                                                                                                                      |
+| `sigul-mock-mode` | no       | `false`        | When `true`, emit deterministic mock signatures locally without contacting a Sigul server. Useful for testing workflow plumbing.                                                                                                                                                                                                                                             |
+
+<!-- markdownlint-enable MD013 -->
 
 ### Requirements
 
@@ -117,11 +140,15 @@ To use the action against a real signing server you need:
 
 This repository builds three containers, all from `fedora:44`:
 
-| Container | Dockerfile | Role |
-| --------- | ---------- | ---- |
-| Client | [`Dockerfile.client`](./Dockerfile.client) | Sigul client used by the action and the integration tests. |
-| Server | [`Dockerfile.server`](./Dockerfile.server) | Sigul server: holds the signing keys, runs SQLite-backed key/user database. |
-| Bridge | [`Dockerfile.bridge`](./Dockerfile.bridge) | Sigul bridge: brokers double-TLS connections between clients and the server. |
+<!-- markdownlint-disable MD013 -->
+
+| Container | Dockerfile                                 | Role                                                                         |
+| --------- | ------------------------------------------ | ---------------------------------------------------------------------------- |
+| Client    | [`Dockerfile.client`](./Dockerfile.client) | Sigul client used by the action and the integration tests.                   |
+| Server    | [`Dockerfile.server`](./Dockerfile.server) | Sigul server: holds the signing keys, runs SQLite-backed key/user database.  |
+| Bridge    | [`Dockerfile.bridge`](./Dockerfile.bridge) | Sigul bridge: brokers double-TLS connections between clients and the server. |
+
+<!-- markdownlint-enable MD013 -->
 
 ### How Sigul is built
 
@@ -169,11 +196,15 @@ with `publish_ghcr: true`) publishes the images to GHCR.
 Workflow trigger: `pull_request` to `main`, plus `workflow_dispatch` with the
 following inputs:
 
-| Input | Default | Purpose |
-| ----- | ------- | ------- |
-| `clear_cache` | `false` | Bypass GitHub Actions cache and rebuild images from scratch. |
-| `enable_auth_debug` | `false` | Set `SIGUL_DEBUG_AUTH=1` in the bridge and server, surfacing `AUTHDBG/*` lines in container logs. |
-| `publish_ghcr` | `true` | Publish freshly-built images to `ghcr.io/<org>/<repo>/sigul-docker`. Untick when iterating on the workflow itself. |
+<!-- markdownlint-disable MD013 -->
+
+| Input               | Default | Purpose                                                                                                            |
+| ------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
+| `clear_cache`       | `false` | Bypass GitHub Actions cache and rebuild images from scratch.                                                       |
+| `enable_auth_debug` | `false` | Set `SIGUL_DEBUG_AUTH=1` in the bridge and server, surfacing `AUTHDBG/*` lines in container logs.                  |
+| `publish_ghcr`      | `true`  | Publish freshly-built images to `ghcr.io/<org>/<repo>/sigul-docker`. Untick when iterating on the workflow itself. |
+
+<!-- markdownlint-enable MD013 -->
 
 ## Local development
 
@@ -357,10 +388,14 @@ failing CI run as the source of truth.
 
 ### Reporting an issue
 
-Use [GitHub Issues](https://github.com/lfreleng-actions/sigul-docker/issues) to report problems and bugs.
+Use [GitHub Issues][gh-issues] to report problems and bugs.
 
 A good report includes the steps to reproduce, what you expected to
 happen versus what actually happened, the relevant container or
 workflow logs, and — for stack-level bugs — the diagnostic bundle
 from `scripts/collect-sigul-diagnostics.sh --compress` (see
 [Troubleshooting](#troubleshooting)).
+
+[pre-commit.ci results page]: https://results.pre-commit.ci/latest/github/lfreleng-actions/sigul-sign-docker/main
+[pre-commit.ci status badge]: https://results.pre-commit.ci/badge/github/lfreleng-actions/sigul-sign-docker/main.svg
+[gh-issues]: https://github.com/lfreleng-actions/sigul-sign-docker/issues

--- a/test/fixtures/sigul-test-rpm.spec
+++ b/test/fixtures/sigul-test-rpm.spec
@@ -22,7 +22,7 @@ Release:        1%{?dist}
 Summary:        Throwaway RPM for Sigul integration signing tests
 
 License:        Apache-2.0
-URL:            https://github.com/lfreleng-actions/sigul-docker
+URL:            https://github.com/lfreleng-actions/sigul-sign-docker
 BuildArch:      noarch
 
 # No Source0: this RPM has no payload to fetch.


### PR DESCRIPTION
## What

Refreshes documentation in preparation for the imminent move of this repository:

- **Org rename**: `modeseven-lfreleng-actions/sigul-sign-docker` → `lfreleng-actions/sigul-sign-docker`
- **Slug fix**: a handful of references to the historical short name `lfreleng-actions/sigul-docker` (without the `-sign-`) — broken today, will be correct post-move

Bundled together so the move itself can land atomically with no further README/docs edits needed afterwards.

> [!NOTE]
> The URLs updated here will **404 in the interim**. That's expected — they go live the moment the rename happens. Copilot will likely flag them as broken; we're ignoring those particular comments. Any other Copilot feedback is fair game.

## Changes

### Org rename (`modeseven-lfreleng-actions` → `lfreleng-actions`)

- `README.md` — 12 badge URLs across the three rows + pre-commit.ci link reference definitions

### Slug fix (`sigul-docker` → `sigul-sign-docker`)

- `README.md` — three `uses: lfreleng-actions/sigul-sign-docker@v1` examples + `gh-issues` reference def
- `OPERATIONS_GUIDE.md` — GitHub Issues URL in Emergency Contacts
- `test/fixtures/sigul-test-rpm.spec` — `URL:` field

### Badge block (the original scope of this PR)

Three logical rows added to the top of `README.md`:

- **Identity & licensing**: Linux Foundation / Source / License / REUSE / Latest Release (link goes to `/releases` so badge + destination agree with `include_prereleases`)
- **CI status**: Build & Test / pre-commit.ci / OpenSSF Scorecard / Zizmor Scan
- **Container packages**: `ghcr.io/.../client`, `/server`, `/bridge`

### markdownlint enablement

- Long badge URLs are wrapped in a matched `<!-- markdownlint-disable MD013 -->` / `<!-- markdownlint-enable MD013 -->` pair so MD013 (line-length) applies to the rest of the README.
- The GitHub Issues link in the Contributing section was refactored from inline (105 chars) to reference-style so the prose line stays under 80 chars.
- Both `README.md` and `DEPLOYMENT_GUIDE.md` now pass `markdownlint-cli v0.48.0` cleanly (same pin as `.pre-commit-config.yaml`); both removed from the markdownlint exclude in pre-commit.
- `OPERATIONS_GUIDE.md` still has pre-existing violations and stays excluded.
- `DEPLOYMENT_GUIDE.md` table formatting was tidied separately via `markdown-table-fixer lint . --auto-fix` (the resulting changes are included here so the file passes markdownlint without further edits).

## Out of scope — tracked for the move PR

- Internal Docker Compose project name + volume / network / fallback image identifiers (the `sigul-docker_*` prefix used throughout `docker-compose.sigul.yml`, scripts, and several docs)
- `action.yml` `name:` field (`sigul-docker` vs `sigul-sign-docker`)
- `build-test.yaml`'s manual-publish path (`IMAGE_NAME: ${{ github.repository }}/sigul-docker`)
- Prose / help-text mentions of `sigul-docker` in scripts and `docs/LOCAL_DEBUG.md`

These were enumerated in the audit and deferred to the move PR — they need decisions (e.g. action.yml name) and/or coordinated find-replace across ~15 files, which is too much for a docs-cleanup PR.

## Local validation

`prek run` on every modified file → **all hooks passed** (`yamllint`, `markdownlint`, `reuse lint`, `codespell`, etc.).