### PR TITLE
Fix: resolve zizmor template injection and permission findings

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,8 +40,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  actions: write  # Required for cache deletion when clear_cache is true
 
 env:
   REGISTRY: ghcr.io
@@ -161,11 +159,13 @@ jobs:
 
       - name: 'Debug cache-clearing input'
         shell: bash
+        env:
+          CLEAR_CACHE: ${{ github.event.inputs.clear_cache }}
         # yamllint disable rule:line-length
         run: |
           echo "🔍 Debugging cache-clearing configuration..."
-          echo "clear_cache input: '${{ github.event.inputs.clear_cache }}'"
-          echo "clear_cache type: $(echo '${{ github.event.inputs.clear_cache }}' | wc -c) chars"
+          echo "clear_cache input: '${CLEAR_CACHE}'"
+          echo "clear_cache type: $(printf '%s' "${CLEAR_CACHE}" | wc -c) chars"
           echo "Condition evaluation: ${{ github.event.inputs.clear_cache == true }}"
           echo "Condition (string): ${{ github.event.inputs.clear_cache == 'true' }}"
         # yamllint enable rule:line-length

--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,20 @@ runs:
   using: "composite"
   steps:
     - name: "Set GitHub user default"
+      id: gh-user
       shell: bash
+      env:
+        INPUT_GH_USER: ${{ inputs.gh-user }}
+        DEFAULT_GH_USER: ${{ github.actor }}
       run: |
-        if [[ -z "${{ inputs.gh-user }}" ]]; then
-          echo "GH_USER=${{ github.actor }}" >> $GITHUB_ENV
+        if [[ -z "${INPUT_GH_USER}" ]]; then
+          echo "user=${DEFAULT_GH_USER}" >> "$GITHUB_OUTPUT"
         else
-          echo "GH_USER=${{ inputs.gh-user }}" >> $GITHUB_ENV
+          echo "user=${INPUT_GH_USER}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: "Detect platform architecture"
+      id: platform
       shell: bash
       run: |
         # Detect the current platform architecture
@@ -71,12 +76,16 @@ runs:
             exit 1
             ;;
         esac
-        echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
-        echo "PLATFORM_ID=$PLATFORM_ID" >> $GITHUB_ENV
+        echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+        echo "platform-id=$PLATFORM_ID" >> "$GITHUB_OUTPUT"
         echo "Detected platform: $PLATFORM ($PLATFORM_ID)"
 
     - name: "Build sigul signing container"
       shell: bash
+      env:
+        PLATFORM: ${{ steps.platform.outputs.platform }}
+        PLATFORM_ID: ${{ steps.platform.outputs.platform-id }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         CLIENT_IMAGE="client-${PLATFORM_ID}-image"
         CLIENT_TAG="client-${PLATFORM_ID}-image:${PLATFORM_ID}"
@@ -95,23 +104,35 @@ runs:
         else
           echo "Docker image not found, building new image for ${PLATFORM}"
           docker build --platform "${PLATFORM}" \
-            -f "${{ github.action_path }}/Dockerfile.client" \
-            -t "${CLIENT_ACTION_TAG}" "${{ github.action_path }}"
+            -f "${ACTION_PATH}/Dockerfile.client" \
+            -t "${CLIENT_ACTION_TAG}" "${ACTION_PATH}"
         fi
 
     - name: "Run sigul signing container"
       shell: bash
+      env:
+        PLATFORM: ${{ steps.platform.outputs.platform }}
+        PLATFORM_ID: ${{ steps.platform.outputs.platform-id }}
+        GH_USER: ${{ steps.gh-user.outputs.user }}
+        SIGN_TYPE: ${{ inputs.sign-type }}
+        SIGN_OBJECT: ${{ inputs.sign-object }}
+        SIGUL_CONF: ${{ inputs.sigul-conf }}
+        SIGUL_KEY_NAME: ${{ inputs.sigul-key-name }}
+        SIGUL_PASS: ${{ inputs.sigul-pass }}
+        SIGUL_PKI: ${{ inputs.sigul-pki }}
+        GH_KEY: ${{ inputs.gh-key }}
+        SIGUL_MOCK_MODE: ${{ inputs.sigul-mock-mode }}
       run: |
         docker run --rm --platform "${PLATFORM}" \
-          -e "SIGN_TYPE=${{ inputs.sign-type }}" \
-          -e "SIGN_OBJECT=${{ inputs.sign-object }}" \
-          -e "SIGUL_CONF=${{ inputs.sigul-conf }}" \
-          -e "SIGUL_KEY_NAME=${{ inputs.sigul-key-name }}" \
-          -e "SIGUL_PASS=${{ inputs.sigul-pass }}" \
-          -e "SIGUL_PKI=${{ inputs.sigul-pki }}" \
+          -e "SIGN_TYPE=${SIGN_TYPE}" \
+          -e "SIGN_OBJECT=${SIGN_OBJECT}" \
+          -e "SIGUL_CONF=${SIGUL_CONF}" \
+          -e "SIGUL_KEY_NAME=${SIGUL_KEY_NAME}" \
+          -e "SIGUL_PASS=${SIGUL_PASS}" \
+          -e "SIGUL_PKI=${SIGUL_PKI}" \
           -e "GH_USER=${GH_USER}" \
-          -e "GH_KEY=${{ inputs.gh-key }}" \
-          -e "SIGUL_MOCK_MODE=${{ inputs.sigul-mock-mode }}" \
+          -e "GH_KEY=${GH_KEY}" \
+          -e "SIGUL_MOCK_MODE=${SIGUL_MOCK_MODE}" \
           -e "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}" \
           -e "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
           -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \


### PR DESCRIPTION
## Summary

The [zizmor security audit](https://github.com/lfreleng-actions/sigul-sign-docker/actions/runs/27491218444)
flagged 10 errors across `action.yml` and `.github/workflows/build-test.yaml`,
spanning three rules:

- `template-injection` — untrusted context expanded directly into `run:` blocks
- `github-env` — user-influenced values written to `GITHUB_ENV`
- `excessive-permissions` — overly broad `packages: write` / `actions: write`
  granted at the workflow level

## Changes

### `action.yml`

- The "Set GitHub user default" step expanded `inputs.gh-user` and
  `github.actor` directly into the shell and wrote `GH_USER` to `GITHUB_ENV`.
  It now binds those values via `env:` and emits a step **output**
  (`steps.gh-user.outputs.user`) instead of writing to `GITHUB_ENV`.
- The "Detect platform architecture" step now publishes `platform` /
  `platform-id` as step **outputs** rather than `GITHUB_ENV` writes.
- The build and run steps consume those outputs and all action inputs through
  `env:` bindings, so every value is referenced as a quoted shell variable
  (`${VAR}`) rather than an inline `${{ ... }}` template expansion. This also
  hardens the `docker run` invocation, which previously interpolated every
  input directly.

### `.github/workflows/build-test.yaml`

- Removed the workflow-level `packages: write` and `actions: write` grants.
  The `build-containers` job already declares `actions: write` and
  `publish-ghcr` already declares `packages: write` at the job level; the
  remaining jobs only need the default `contents: read`.
- The "Debug cache-clearing input" step now passes `github.event.inputs.clear_cache`
  through an `env:` binding instead of expanding it inline in the `run:` block.

## Validation

- `yamllint` passes on both files (pre-existing `comments-indentation`
  warnings are unrelated to these changes).
- `zizmor --offline` no longer reports any `template-injection`, `github-env`,
  or `excessive-permissions` findings on the previously flagged locations. The
  remaining `artipacked` warnings are pre-existing and out of scope for this
  change.

Behaviour is unchanged; the platform detection, container build, signing run,
and cache-clearing flows operate exactly as before.
