### PR TITLE
Fix: pin Fedora base image by digest for Scorecard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,14 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 15
+
+  # Keep the pinned Fedora base-image digest in the Dockerfiles current.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Build(docker)"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15

--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Simplified Dockerfile for sigul bridge using dedicated build scripts
-FROM fedora:44
+# Base image pinned by digest for supply-chain integrity (Scorecard
+# Pinned-Dependencies). Dependabot maintains the digest via the docker
+# ecosystem entry in .github/dependabot.yml.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 # Standard OCI metadata labels (image.title, image.description,

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Unified Dockerfile for sigul client using the new cert-init approach
-FROM fedora:44
+# Base image pinned by digest for supply-chain integrity (Scorecard
+# Pinned-Dependencies). Dependabot maintains the digest via the docker
+# ecosystem entry in .github/dependabot.yml.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 # Standard OCI metadata labels (image.title, image.description,

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Simplified Dockerfile for sigul server using dedicated build scripts
-FROM fedora:44
+# Base image pinned by digest for supply-chain integrity (Scorecard
+# Pinned-Dependencies). Dependabot maintains the digest via the docker
+# ecosystem entry in .github/dependabot.yml.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 # Standard OCI metadata labels (image.title, image.description,


### PR DESCRIPTION
## Summary

OpenSSF Scorecard raised `Pinned-Dependencies` (Medium) findings against
all three container builds because the base image was referenced by the
floating `fedora:44` tag:

- `Dockerfile.bridge:5`
- `Dockerfile.client:5`
- `Dockerfile.server:5`

A floating tag lets the resolved image content drift between builds, which
weakens supply-chain integrity and is what Scorecard flags.

## Changes

- Pin all three Dockerfiles to the current multi-arch `fedora:44`
  manifest-list digest
  `sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898`.
  The digest is the OCI image **index**, which contains both `linux/amd64`
  and `linux/arm64`, so the existing multi-platform build matrix continues
  to resolve the correct per-arch image.
- Add a `docker` `package-ecosystem` entry to `.github/dependabot.yml` so
  the pinned digest is bumped automatically as new Fedora 44 images ship.
  This keeps the base image patched without reintroducing a floating tag.

## Validation

- `yamllint` passes on `.github/dependabot.yml`.
- Digest resolved directly from the Docker Hub registry API for
  `library/fedora:44`; the index covers amd64 + arm64 (and additional
  arches) so no platform regression.

## Notes

The retained `:44` tag alongside the digest is for human readability only;
Docker resolves strictly by digest when one is present.
