### PR TITLE
Fix: resolve zizmor and Scorecard security audit findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,14 @@ updates:
     cooldown:
       default-days: 7
     open-pull-requests-limit: 15
+
+  # Keep the pinned Fedora base-image digest in the Dockerfiles current.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Build(docker)"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,8 +40,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-  actions: write  # Required for cache deletion when clear_cache is true
 
 env:
   REGISTRY: ghcr.io
@@ -161,11 +159,13 @@ jobs:
 
       - name: 'Debug cache-clearing input'
         shell: bash
+        env:
+          CLEAR_CACHE: ${{ github.event.inputs.clear_cache }}
         # yamllint disable rule:line-length
         run: |
           echo "🔍 Debugging cache-clearing configuration..."
-          echo "clear_cache input: '${{ github.event.inputs.clear_cache }}'"
-          echo "clear_cache type: $(echo '${{ github.event.inputs.clear_cache }}' | wc -c) chars"
+          echo "clear_cache input: '${CLEAR_CACHE}'"
+          echo "clear_cache type: $(printf '%s' "${CLEAR_CACHE}" | wc -c) chars"
           echo "Condition evaluation: ${{ github.event.inputs.clear_cache == true }}"
           echo "Condition (string): ${{ github.event.inputs.clear_cache == 'true' }}"
         # yamllint enable rule:line-length

--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Simplified Dockerfile for sigul bridge using dedicated build scripts
-FROM fedora:44
+# Base image pinned by digest for supply-chain integrity (Scorecard
+# Pinned-Dependencies). Dependabot maintains the digest via the docker
+# ecosystem entry in .github/dependabot.yml.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 # Standard OCI metadata labels (image.title, image.description,

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Unified Dockerfile for sigul client using the new cert-init approach
-FROM fedora:44
+# Base image pinned by digest for supply-chain integrity (Scorecard
+# Pinned-Dependencies). Dependabot maintains the digest via the docker
+# ecosystem entry in .github/dependabot.yml.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 # Standard OCI metadata labels (image.title, image.description,

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # Simplified Dockerfile for sigul server using dedicated build scripts
-FROM fedora:44
+# Base image pinned by digest for supply-chain integrity (Scorecard
+# Pinned-Dependencies). Dependabot maintains the digest via the docker
+# ecosystem entry in .github/dependabot.yml.
+FROM fedora:44@sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898
 
 LABEL maintainer="releng@linuxfoundation.org"
 # Standard OCI metadata labels (image.title, image.description,

--- a/action.yml
+++ b/action.yml
@@ -50,11 +50,17 @@ runs:
         INPUT_GH_USER: ${{ inputs.gh-user }}
         DEFAULT_GH_USER: ${{ github.actor }}
       run: |
-        if [[ -z "${INPUT_GH_USER}" ]]; then
-          echo "user=${DEFAULT_GH_USER}" >> "$GITHUB_OUTPUT"
-        else
-          echo "user=${INPUT_GH_USER}" >> "$GITHUB_OUTPUT"
-        fi
+        GH_USER="${INPUT_GH_USER:-$DEFAULT_GH_USER}"
+        # Emit the value using the documented multiline output syntax with
+        # an unpredictable delimiter. The name=value form would let a value
+        # containing newlines inject additional step outputs; the heredoc
+        # delimiter encodes arbitrary input safely.
+        delimiter="ghadelimiter_${RANDOM}${RANDOM}${RANDOM}"
+        {
+          printf 'user<<%s\n' "${delimiter}"
+          printf '%s\n' "${GH_USER}"
+          printf '%s\n' "${delimiter}"
+        } >> "$GITHUB_OUTPUT"
 
     - name: "Detect platform architecture"
       id: platform
@@ -77,14 +83,14 @@ runs:
             ;;
         esac
         echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
-        echo "platform-id=$PLATFORM_ID" >> "$GITHUB_OUTPUT"
+        echo "platform_id=$PLATFORM_ID" >> "$GITHUB_OUTPUT"
         echo "Detected platform: $PLATFORM ($PLATFORM_ID)"
 
     - name: "Build sigul signing container"
       shell: bash
       env:
         PLATFORM: ${{ steps.platform.outputs.platform }}
-        PLATFORM_ID: ${{ steps.platform.outputs.platform-id }}
+        PLATFORM_ID: ${{ steps.platform.outputs.platform_id }}
         ACTION_PATH: ${{ github.action_path }}
       run: |
         CLIENT_IMAGE="client-${PLATFORM_ID}-image"
@@ -112,7 +118,7 @@ runs:
       shell: bash
       env:
         PLATFORM: ${{ steps.platform.outputs.platform }}
-        PLATFORM_ID: ${{ steps.platform.outputs.platform-id }}
+        PLATFORM_ID: ${{ steps.platform.outputs.platform_id }}
         GH_USER: ${{ steps.gh-user.outputs.user }}
         SIGN_TYPE: ${{ inputs.sign-type }}
         SIGN_OBJECT: ${{ inputs.sign-object }}

--- a/action.yml
+++ b/action.yml
@@ -44,15 +44,20 @@ runs:
   using: "composite"
   steps:
     - name: "Set GitHub user default"
+      id: gh-user
       shell: bash
+      env:
+        INPUT_GH_USER: ${{ inputs.gh-user }}
+        DEFAULT_GH_USER: ${{ github.actor }}
       run: |
-        if [[ -z "${{ inputs.gh-user }}" ]]; then
-          echo "GH_USER=${{ github.actor }}" >> $GITHUB_ENV
+        if [[ -z "${INPUT_GH_USER}" ]]; then
+          echo "user=${DEFAULT_GH_USER}" >> "$GITHUB_OUTPUT"
         else
-          echo "GH_USER=${{ inputs.gh-user }}" >> $GITHUB_ENV
+          echo "user=${INPUT_GH_USER}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: "Detect platform architecture"
+      id: platform
       shell: bash
       run: |
         # Detect the current platform architecture
@@ -71,12 +76,16 @@ runs:
             exit 1
             ;;
         esac
-        echo "PLATFORM=$PLATFORM" >> $GITHUB_ENV
-        echo "PLATFORM_ID=$PLATFORM_ID" >> $GITHUB_ENV
+        echo "platform=$PLATFORM" >> "$GITHUB_OUTPUT"
+        echo "platform-id=$PLATFORM_ID" >> "$GITHUB_OUTPUT"
         echo "Detected platform: $PLATFORM ($PLATFORM_ID)"
 
     - name: "Build sigul signing container"
       shell: bash
+      env:
+        PLATFORM: ${{ steps.platform.outputs.platform }}
+        PLATFORM_ID: ${{ steps.platform.outputs.platform-id }}
+        ACTION_PATH: ${{ github.action_path }}
       run: |
         CLIENT_IMAGE="client-${PLATFORM_ID}-image"
         CLIENT_TAG="client-${PLATFORM_ID}-image:${PLATFORM_ID}"
@@ -95,23 +104,35 @@ runs:
         else
           echo "Docker image not found, building new image for ${PLATFORM}"
           docker build --platform "${PLATFORM}" \
-            -f "${{ github.action_path }}/Dockerfile.client" \
-            -t "${CLIENT_ACTION_TAG}" "${{ github.action_path }}"
+            -f "${ACTION_PATH}/Dockerfile.client" \
+            -t "${CLIENT_ACTION_TAG}" "${ACTION_PATH}"
         fi
 
     - name: "Run sigul signing container"
       shell: bash
+      env:
+        PLATFORM: ${{ steps.platform.outputs.platform }}
+        PLATFORM_ID: ${{ steps.platform.outputs.platform-id }}
+        GH_USER: ${{ steps.gh-user.outputs.user }}
+        SIGN_TYPE: ${{ inputs.sign-type }}
+        SIGN_OBJECT: ${{ inputs.sign-object }}
+        SIGUL_CONF: ${{ inputs.sigul-conf }}
+        SIGUL_KEY_NAME: ${{ inputs.sigul-key-name }}
+        SIGUL_PASS: ${{ inputs.sigul-pass }}
+        SIGUL_PKI: ${{ inputs.sigul-pki }}
+        GH_KEY: ${{ inputs.gh-key }}
+        SIGUL_MOCK_MODE: ${{ inputs.sigul-mock-mode }}
       run: |
         docker run --rm --platform "${PLATFORM}" \
-          -e "SIGN_TYPE=${{ inputs.sign-type }}" \
-          -e "SIGN_OBJECT=${{ inputs.sign-object }}" \
-          -e "SIGUL_CONF=${{ inputs.sigul-conf }}" \
-          -e "SIGUL_KEY_NAME=${{ inputs.sigul-key-name }}" \
-          -e "SIGUL_PASS=${{ inputs.sigul-pass }}" \
-          -e "SIGUL_PKI=${{ inputs.sigul-pki }}" \
+          -e "SIGN_TYPE=${SIGN_TYPE}" \
+          -e "SIGN_OBJECT=${SIGN_OBJECT}" \
+          -e "SIGUL_CONF=${SIGUL_CONF}" \
+          -e "SIGUL_KEY_NAME=${SIGUL_KEY_NAME}" \
+          -e "SIGUL_PASS=${SIGUL_PASS}" \
+          -e "SIGUL_PKI=${SIGUL_PKI}" \
           -e "GH_USER=${GH_USER}" \
-          -e "GH_KEY=${{ inputs.gh-key }}" \
-          -e "SIGUL_MOCK_MODE=${{ inputs.sigul-mock-mode }}" \
+          -e "GH_KEY=${GH_KEY}" \
+          -e "SIGUL_MOCK_MODE=${SIGUL_MOCK_MODE}" \
           -e "GITHUB_WORKSPACE=${GITHUB_WORKSPACE}" \
           -e "GITHUB_REPOSITORY=${GITHUB_REPOSITORY}" \
           -v "${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" \


### PR DESCRIPTION
## Summary

Consolidates the two security-audit remediations (previously #117 and
#118) into a single PR, both addressing findings from the zizmor audit
and OpenSSF Scorecard.

## 1. zizmor: template-injection, github-env, excessive-permissions

`action.yml`:
- The "Set GitHub user default" step expanded `inputs.gh-user` and
  `github.actor` directly into the shell and wrote `GH_USER` to
  `GITHUB_ENV`. It now binds those values via `env:` and emits a step
  **output** (`steps.gh-user.outputs.user`) instead of writing to
  `GITHUB_ENV`.
- "Detect platform architecture" now publishes `platform` / `platform-id`
  as step **outputs** rather than `GITHUB_ENV` writes.
- The build and run steps consume those outputs and all action inputs
  through `env:` bindings, so every value is a quoted shell variable
  rather than an inline `${{ ... }}` expansion (also hardens the
  `docker run` invocation, which previously interpolated every input).

`.github/workflows/build-test.yaml`:
- Removed the workflow-level `packages: write` and `actions: write`
  grants. `build-containers` already declares `actions: write` and
  `publish-ghcr` already declares `packages: write` at the job level; the
  remaining jobs only need the default `contents: read`.
- "Debug cache-clearing input" now passes `github.event.inputs.clear_cache`
  via an `env:` binding instead of expanding it inline in the `run:` block.

## 2. Scorecard: Pinned-Dependencies

- Pinned `Dockerfile.bridge`, `Dockerfile.client`, and `Dockerfile.server`
  to the current multi-arch `fedora:44` manifest-list digest
  `sha256:6c75d5bf57cb0fa5aa4b92c6a83c86c791644496d9ac230de7711f5b8ec3b898`.
  The digest is the OCI image index (amd64 + arm64), so the multi-platform
  build matrix is unaffected. At time of pinning this digest is also what
  `fedora:latest` resolves to (Fedora 45 is still rawhide).
- Added a `docker` `package-ecosystem` entry to `.github/dependabot.yml`
  so the pinned digest is bumped automatically as new Fedora 44 images
  ship, keeping the base image patched without a floating tag.

## Note on the Grype `openssl-libs` failure

The recent Grype failures (`openssl-libs 3.5.5-2.fc44`, fixed in
`3.5.7-1.fc44`, FEDORA-2026-228373a496) are **not** caused by the base-image
pin. That advisory reached Fedora 44 **stable** on 2026-06-12, and the
Dockerfiles already run `dnf update -y` as their first build step. The
stale result came from the BuildKit `gha` cache reusing the old
`dnf update` layer; a `clear_cache` run forces it to re-resolve and pull
`3.5.7`. The new `docker` dependabot entry plus periodic cache clears keep
this current going forward.

## Validation

- `yamllint` passes on the changed YAML files.
- `zizmor --offline` reports no `template-injection`, `github-env`, or
  `excessive-permissions` findings at the previously flagged locations.
- Base-image digest resolved directly from the Docker Hub registry API for
  `library/fedora:44` (covers amd64 + arm64).

Closes #117. Closes #118.
