### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -52,8 +52,8 @@ jobs:
     name: 'Repository Metadata'
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Checkout repository contents
+      pull-requests: read  # Gather pull request metadata
     timeout-minutes: 5
     steps:
       # Load the egress allow-list out-of-band from the
@@ -78,6 +78,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Gather repository metadata'
         id: repo-metadata
@@ -167,6 +168,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Set up Docker Buildx'
         # yamllint disable-line rule:line-length
@@ -176,13 +179,15 @@ jobs:
         shell: bash
         env:
           CLEAR_CACHE: ${{ github.event.inputs.clear_cache }}
+          COND_BOOLEAN: ${{ github.event.inputs.clear_cache == true }}
+          COND_STRING: ${{ github.event.inputs.clear_cache == 'true' }}
         # yamllint disable rule:line-length
         run: |
           echo "🔍 Debugging cache-clearing configuration..."
           echo "clear_cache input: '${CLEAR_CACHE}'"
           echo "clear_cache type: $(printf '%s' "${CLEAR_CACHE}" | wc -c) chars"
-          echo "Condition evaluation: ${{ github.event.inputs.clear_cache == true }}"
-          echo "Condition (string): ${{ github.event.inputs.clear_cache == 'true' }}"
+          echo "Condition evaluation: ${COND_BOOLEAN}"
+          echo "Condition (string): ${COND_STRING}"
         # yamllint enable rule:line-length
 
       - name: 'Clear build caches if requested'
@@ -201,8 +206,10 @@ jobs:
       - name: 'Extract platform identifier'
         id: platform
         shell: bash
+        env:
+          MATRIX_PLATFORM: ${{ matrix.platform }}
         run: |
-          platform_id="${{ matrix.platform }}"
+          platform_id="${MATRIX_PLATFORM}"
           platform_id="${platform_id//\//-}"
           echo "id=${platform_id}" >> "$GITHUB_OUTPUT"
           echo "Platform ID: ${platform_id}"
@@ -236,7 +243,11 @@ jobs:
         with:
           context: .
           file: Dockerfile.${{ matrix.component }}
-          platforms: ${{ matrix.runner == 'ubuntu-24.04-arm' && '' || matrix.platform }}
+          # The former pseudo-ternary here
+          # (runner == arm && '' || matrix.platform) always evaluated
+          # to matrix.platform because the empty string is falsy, so
+          # reference matrix.platform directly (identical behaviour).
+          platforms: ${{ matrix.platform }}
           # Local-only build tag. The publish-ghcr job below applies
           # the manual-<sha> tag if a maintainer opts into
           # publishing.
@@ -299,8 +310,8 @@ jobs:
     name: 'Publish: ${{ matrix.component }}'
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
-      packages: write
+      contents: read  # Checkout repository contents
+      packages: write  # Push container images to GHCR
     timeout-minutes: 10
     needs: [build-containers]
     # Pull-request triggers never publish.  workflow_dispatch only
@@ -336,6 +347,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Set up Docker Buildx'
         # yamllint disable-line rule:line-length
@@ -365,24 +378,27 @@ jobs:
 
       - name: 'Load platform images'
         shell: bash
+        env:
+          COMPONENT: ${{ matrix.component }}
         run: |
           set -euo pipefail
-          docker load --input /tmp/${{ matrix.component }}-linux-amd64.tar
-          docker load --input /tmp/${{ matrix.component }}-linux-arm64.tar
-          docker images | grep '^${{ matrix.component }} ' || true
+          docker load --input "/tmp/${COMPONENT}-linux-amd64.tar"
+          docker load --input "/tmp/${COMPONENT}-linux-arm64.tar"
+          docker images | grep "^${COMPONENT} " || true
 
       # yamllint disable rule:line-length
       - name: 'Push images and create multi-arch manifest'
         shell: bash
         env:
+          COMPONENT: ${{ matrix.component }}
           IMAGE: ${{ env.REGISTRY }}/${{ github.repository }}/${{ matrix.component }}
           TAG: manual-${{ github.sha }}
         run: |
           set -euo pipefail
 
           # Per-arch images
-          docker tag "${{ matrix.component }}:linux-amd64" "${IMAGE}:${TAG}-amd64"
-          docker tag "${{ matrix.component }}:linux-arm64" "${IMAGE}:${TAG}-arm64"
+          docker tag "${COMPONENT}:linux-amd64" "${IMAGE}:${TAG}-amd64"
+          docker tag "${COMPONENT}:linux-arm64" "${IMAGE}:${TAG}-arm64"
           docker push "${IMAGE}:${TAG}-amd64"
           docker push "${IMAGE}:${TAG}-arm64"
 
@@ -530,7 +546,7 @@ jobs:
       # this scope is silently downgraded to read; the upload step
       # is wrapped in continue-on-error so the scan still produces
       # the downloadable SARIF artifact in that case.
-      security-events: write
+      security-events: write  # Upload Grype SARIF to code scanning
     timeout-minutes: 15
     strategy:
       # Don't short-circuit other components if one's Grype scan
@@ -757,6 +773,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Set up Docker Buildx'
         # yamllint disable-line rule:line-length
@@ -1270,6 +1288,14 @@ jobs:
     steps:
       - name: 'Generate deploy summary'
         shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build-containers.result }}
+          SBOM_RESULT: ${{ needs.pr-sbom.result }}
+          GRYPE_RESULT: ${{ needs.pr-grype.result }}
+          TESTS_RESULT: ${{ needs.functional-tests.result }}
+          PUBLISH_RESULT: ${{ needs.publish-ghcr.result }}
+          REGISTRY_NAME: ${{ env.REGISTRY }}
+          IMAGE: ${{ env.IMAGE_NAME }}
         run: |
           {
             echo "## Sigul Deploy Summary 🐳"
@@ -1279,13 +1305,13 @@ jobs:
             echo "| Job | Status |"
             echo "|-----|--------|"
             echo "| Build (matrix: amd64 + arm64) |" \
-              " ${{ needs.build-containers.result }} |"
+              " ${BUILD_RESULT} |"
             echo "| SBOM (matrix: 3 components) |" \
-              " ${{ needs.pr-sbom.result }} |"
+              " ${SBOM_RESULT} |"
             echo "| Grype (matrix: 3 components) |" \
-              " ${{ needs.pr-grype.result }} |"
+              " ${GRYPE_RESULT} |"
             echo "| Functional Tests (matrix: amd64 + arm64) |" \
-              " ${{ needs.functional-tests.result }} |"
+              " ${TESTS_RESULT} |"
             echo ""
 
             # Note: needs.<job>.result is the *overall* matrix outcome
@@ -1296,13 +1322,13 @@ jobs:
             # individual matrix legs in the UI for per-platform detail.
 
             echo "### Functional Tests"
-            echo "- **Status**: ${{ needs.functional-tests.result }}"
+            echo "- **Status**: ${TESTS_RESULT}"
             echo "- **Includes**: Integration testing against fresh infrastructure"
             echo ""
 
             echo "### Supply-chain scan"
-            echo "- **SBOM status**: ${{ needs.pr-sbom.result }}"
-            echo "- **Grype status**: ${{ needs.pr-grype.result }}"
+            echo "- **SBOM status**: ${SBOM_RESULT}"
+            echo "- **Grype status**: ${GRYPE_RESULT}"
             echo "- **Includes**: SPDX SBOM (anchore/sbom-action)" \
               "and Grype vulnerability scan per component image"
             echo "- **Artifacts**: pr-sbom-and-scan-COMPONENT per" \
@@ -1314,16 +1340,16 @@ jobs:
             echo ""
 
             echo "### GHCR Publishing"
-            echo "- **Registry**: ${{ env.REGISTRY }}"
-            echo "- **Image**: ${{ env.IMAGE_NAME }}"
-            echo "- **Status**: ${{ needs.publish-ghcr.result }}"
+            echo "- **Registry**: ${REGISTRY_NAME}"
+            echo "- **Image**: ${IMAGE}"
+            echo "- **Status**: ${PUBLISH_RESULT}"
             echo "- **Method**: Pre-built artifacts (no rebuild)"
             echo ""
 
-            if [ "${{ needs.publish-ghcr.result }}" = "success" ]; then
+            if [ "${PUBLISH_RESULT}" = "success" ]; then
               echo "✅ **Optimization Success**: Images were published using " \
                 "pre-built artifacts, avoiding duplicate builds!"
-            elif [ "${{ needs.publish-ghcr.result }}" = "skipped" ]; then
+            elif [ "${PUBLISH_RESULT}" = "skipped" ]; then
               echo "⏭️ **Publishing Skipped**: " \
               "pull requests cannot publish containers."
             else

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -263,38 +263,50 @@ jobs:
       - name: 'Set build outputs for client amd64'
         id: build-client-amd64
         if: matrix.component == 'client' && matrix.platform == 'linux/amd64'
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
         run: |
-          echo "digest=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: 'Set build outputs for client arm64'
         id: build-client-arm64
         if: matrix.component == 'client' && matrix.platform == 'linux/arm64'
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
         run: |
-          echo "digest=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: 'Set build outputs for server amd64'
         id: build-server-amd64
         if: matrix.component == 'server' && matrix.platform == 'linux/amd64'
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
         run: |
-          echo "digest=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: 'Set build outputs for server arm64'
         id: build-server-arm64
         if: matrix.component == 'server' && matrix.platform == 'linux/arm64'
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
         run: |
-          echo "digest=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: 'Set build outputs for bridge amd64'
         id: build-bridge-amd64
         if: matrix.component == 'bridge' && matrix.platform == 'linux/amd64'
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
         run: |
-          echo "digest=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: 'Set build outputs for bridge arm64'
         id: build-bridge-arm64
         if: matrix.component == 'bridge' && matrix.platform == 'linux/arm64'
+        env:
+          DIGEST: ${{ steps.docker-build.outputs.digest }}
         run: |
-          echo "digest=${{ steps.docker-build.outputs.digest }}" >> "$GITHUB_OUTPUT"
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
       - name: 'Upload ${{ matrix.component }} image as artifact'
         # yamllint disable-line rule:line-length
@@ -829,9 +841,10 @@ jobs:
 
       - name: 'Load and tag container images'
         shell: bash
+        env:
+          PLATFORM_ID: ${{ steps.runner-arch.outputs.platform-id }}
         run: |
           # Loading/tagging container images
-          PLATFORM_ID="${{ steps.runner-arch.outputs.platform-id }}"
           echo "🔧 Loading/tagging ${PLATFORM_ID} container images for" \
             "functional tests"
 

--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -46,8 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
-      # Actions cache deletion requires the actions: write scope.
-      actions: write
+      # yamllint disable-line rule:line-length
+      actions: write  # Required to list and delete repository Actions caches
     steps:
       # Load the egress allow-list out-of-band from the
       # organisation's .github repository and publish it as
@@ -70,13 +70,15 @@ jobs:
         id: before
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
+          DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # List current cache entries (pre-deletion snapshot).
           set -euo pipefail
 
-          echo "Repository: ${{ github.repository }}"
+          echo "Repository: $REPO"
           echo "Key filter: '${KEY_PATTERN:-<none>}'"
           echo "Ref filter: '${REF_FILTER:-<none>}'"
           echo ""
@@ -88,7 +90,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/$REPO/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 
@@ -141,7 +143,7 @@ jobs:
             echo "|----------|-------|"
             echo "| Total entries | $before_count |"
             echo "| Matched | $matched_count |"
-            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+            echo "| Dry run | \`${DRY_RUN}\` |"
             echo ""
             # Render user-controlled filter inputs inside a fenced
             # code block. KEY_PATTERN and REF_FILTER are free-form
@@ -184,6 +186,7 @@ jobs:
         id: delete
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # Delete the matched cache IDs unless this is a dry run.
@@ -216,7 +219,7 @@ jobs:
             if gh api \
                 --method DELETE \
                 -H "Accept: application/vnd.github+json" \
-                "/repos/${{ github.repository }}/actions/caches/${cache_id}";
+                "/repos/$REPO/actions/caches/${cache_id}";
             then
               deleted=$((deleted + 1))
             else
@@ -249,6 +252,7 @@ jobs:
         if: always() && steps.before.outputs.matched_count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           KEY_PATTERN: ${{ inputs.key_pattern }}
           REF_FILTER: ${{ inputs.ref_filter }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -261,7 +265,7 @@ jobs:
             gh api \
               --paginate \
               -H "Accept: application/vnd.github+json" \
-              "/repos/${{ github.repository }}/actions/caches?per_page=100" \
+              "/repos/$REPO/actions/caches?per_page=100" \
               --jq '.actions_caches[]'
           )
 

--- a/.github/workflows/openssf-scorecard.yaml
+++ b/.github/workflows/openssf-scorecard.yaml
@@ -7,6 +7,8 @@
 # policy, and support documentation.
 
 name: "OpenSSF Scorecard"
+
+# yamllint disable-line rule:truthy
 on:
   workflow_dispatch:
   # For Branch-Protection check. Only the default branch is supported. See
@@ -25,19 +27,12 @@ permissions: {}
 jobs:
   openssf-scorecard:
     name: "OpenSSF Scorecard"
-    # NOTE: GitHub Actions does not allow `timeout-minutes` on jobs
-    # that call a reusable workflow via `uses:`.  The reusable
-    # workflow defines its own per-job timeouts.  The repository's
-    # `Check GitHub Workflows set timeout-minutes` pre-commit hook
-    # therefore correctly skips this job.
     # yamllint disable-line rule:line-length
-    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@f412e6f89527da7611a5f4a5f861de86d98d3e9e  # v0.7.0
+    uses: lfit/releng-reusable-workflows/.github/workflows/reuse-openssf-scorecard.yaml@fd3c1b43bc919e9e70787b009ffa2768ddbb1267  # v0.7.2
     permissions:
-      # Needed to read repository contents (checkout, etc.).
-      contents: read
-      # Needed to upload the results to the code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and obtain a Scorecard badge via OIDC.
-      id-token: write
+      contents: read  # Read repository contents (checkout, etc.)
+      # yamllint disable-line rule:line-length
+      security-events: write  # Upload results to the code-scanning dashboard
+      id-token: write  # Publish results and obtain Scorecard badge via OIDC
       # Uncomment the permission below if installing in a private repository.
       # actions: read

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,8 +20,7 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
@@ -43,4 +42,4 @@ jobs:
             ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,8 +60,8 @@ jobs:
     name: 'Repository Metadata'
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
-      pull-requests: read
+      contents: read  # Checkout repository contents
+      pull-requests: read  # Gather pull request metadata
     timeout-minutes: 5
     steps:
       # Load the egress allow-list out-of-band from the
@@ -86,6 +86,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: 'Gather repository metadata'
         id: repo-metadata
@@ -138,6 +139,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - name: 'Validate tag'
         id: validate
@@ -217,6 +219,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Set up Docker Buildx'
         # yamllint disable-line rule:line-length
@@ -225,8 +229,10 @@ jobs:
       - name: 'Compute platform identifier'
         id: platform
         shell: bash
+        env:
+          MATRIX_PLATFORM: ${{ matrix.platform }}
         run: |
-          platform_id=$(echo "${{ matrix.platform }}" | tr '/' '-')
+          platform_id=$(echo "${MATRIX_PLATFORM}" | tr '/' '-')
           echo "id=${platform_id}" >> "$GITHUB_OUTPUT"
 
       # Generate the full standard OCI label set from the workflow
@@ -253,7 +259,11 @@ jobs:
           file: 'Dockerfile.${{ matrix.component }}'
           # ARM runners build natively, AMD runners build for amd64;
           # buildx still needs the platforms hint for non-native legs.
-          platforms: ${{ matrix.runner == 'ubuntu-24.04-arm' && '' || matrix.platform }}
+          # The former pseudo-ternary here
+          # (runner == arm && '' || matrix.platform) always evaluated
+          # to matrix.platform because the empty string is falsy, so
+          # reference matrix.platform directly (identical behaviour).
+          platforms: ${{ matrix.platform }}
           tags: |
             ${{ matrix.component }}:${{ steps.platform.outputs.id }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -302,6 +312,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Set up Docker Buildx'
         # yamllint disable-line rule:line-length
@@ -310,8 +322,10 @@ jobs:
       - name: 'Compute platform identifier'
         id: platform
         shell: bash
+        env:
+          MATRIX_PLATFORM: ${{ matrix.platform }}
         run: |
-          platform_id=$(echo "${{ matrix.platform }}" | tr '/' '-')
+          platform_id=$(echo "${MATRIX_PLATFORM}" | tr '/' '-')
           echo "id=${platform_id}" >> "$GITHUB_OUTPUT"
 
       - name: 'Download client image artifact'
@@ -497,10 +511,12 @@ jobs:
 
       - name: 'Load image from tar artifact'
         shell: bash
+        env:
+          COMPONENT: ${{ matrix.component }}
         run: |
           set -euo pipefail
-          docker load --input /tmp/${{ matrix.component }}-linux-amd64.tar
-          docker images | grep "^${{ matrix.component }} " || true
+          docker load --input "/tmp/${COMPONENT}-linux-amd64.tar"
+          docker images | grep "^${COMPONENT} " || true
 
       - name: 'Generate SPDX SBOM'
         # The SBOM is generated from the amd64 leg only and used as
@@ -580,7 +596,7 @@ jobs:
       contents: read
       # github/codeql-action/upload-sarif publishes Grype findings
       # to the repository's code-scanning alerts.
-      security-events: write
+      security-events: write  # Upload Grype SARIF to code scanning
     timeout-minutes: 15
     strategy:
       # Don't short-circuit other components if one's Grype audit
@@ -776,8 +792,8 @@ jobs:
     needs: [tag-validate, functional-tests, grype]
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
-      packages: write
+      contents: read  # Checkout repository contents
+      packages: write  # Push release container images to GHCR
     timeout-minutes: 15
     strategy:
       fail-fast: false
@@ -804,6 +820,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Set up Docker Buildx'
         # yamllint disable-line rule:line-length
@@ -864,11 +882,13 @@ jobs:
 
       - name: 'Load platform images from tar artifacts'
         shell: bash
+        env:
+          COMPONENT: ${{ matrix.component }}
         run: |
           set -euo pipefail
-          docker load --input /tmp/${{ matrix.component }}-linux-amd64.tar
-          docker load --input /tmp/${{ matrix.component }}-linux-arm64.tar
-          docker images | grep '^${{ matrix.component }} ' || true
+          docker load --input "/tmp/${COMPONENT}-linux-amd64.tar"
+          docker load --input "/tmp/${COMPONENT}-linux-arm64.tar"
+          docker images | grep "^${COMPONENT} " || true
 
       - name: 'Push per-arch images and assemble multi-arch index'
         # Push each platform image exactly once under a stable
@@ -890,9 +910,11 @@ jobs:
         # per-tag-per-arch push loop.
         shell: bash
         env:
+          COMPONENT: ${{ matrix.component }}
           # yamllint disable-line rule:line-length
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/${{ matrix.component }}
           FULL_TAG: ${{ needs.tag-validate.outputs.tag }}
+          META_TAGS: ${{ steps.meta.outputs.tags }}
         # yamllint disable rule:line-length
         run: |
           set -euo pipefail
@@ -900,7 +922,7 @@ jobs:
           # Pre-flight: refuse to push if metadata-action produced
           # no tags, or if any computed tag is malformed (ends with
           # ':' which would mean an empty version).
-          mapfile -t tags <<< "${{ steps.meta.outputs.tags }}"
+          mapfile -t tags <<< "${META_TAGS}"
           nonempty=()
           for t in "${tags[@]}"; do
               [[ -n "${t}" ]] || continue
@@ -922,8 +944,8 @@ jobs:
           # per-arch references and serve as the imagetools inputs.
           amd64_src="${IMAGE}:${FULL_TAG}-amd64"
           arm64_src="${IMAGE}:${FULL_TAG}-arm64"
-          docker tag "${{ matrix.component }}:linux-amd64" "${amd64_src}"
-          docker tag "${{ matrix.component }}:linux-arm64" "${arm64_src}"
+          docker tag "${COMPONENT}:linux-amd64" "${amd64_src}"
+          docker tag "${COMPONENT}:linux-arm64" "${arm64_src}"
           docker push "${amd64_src}"
           docker push "${arm64_src}"
 
@@ -938,14 +960,16 @@ jobs:
           docker buildx imagetools create \
               "${tag_args[@]}" \
               "${amd64_src}" "${arm64_src}"
-          echo "✅ Published multi-arch indexes for ${{ matrix.component }}"
+          echo "✅ Published multi-arch indexes for ${COMPONENT}"
         # yamllint enable rule:line-length
 
       - name: 'Verify pushed manifests'
         shell: bash
+        env:
+          META_TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           set -euo pipefail
-          mapfile -t tags <<< "${{ steps.meta.outputs.tags }}"
+          mapfile -t tags <<< "${META_TAGS}"
           for tag in "${tags[@]}"; do
               [[ -n "${tag}" ]] || continue
               echo "=== ${tag} ==="
@@ -964,14 +988,14 @@ jobs:
     needs: [tag-validate, publish-ghcr, sbom]
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: read
-      packages: write
-      # cosign keyless signing + attestation predicates use OIDC.
-      id-token: write
+      contents: read  # Checkout repository contents
+      packages: write  # Attach signatures/attestations as OCI referrers
+      # yamllint disable-line rule:line-length
+      id-token: write  # cosign keyless signing + attestation predicates use OIDC
       # actions/attest-build-provenance + actions/attest write
       # signed attestations and (with push-to-registry: true) attach
       # them as OCI referrers on the manifest digest.
-      attestations: write
+      attestations: write  # Write signed build attestations
     timeout-minutes: 20
     strategy:
       # Don't short-circuit other components if one fails; we want
@@ -1117,7 +1141,7 @@ jobs:
       always() && needs.tag-validate.result == 'success'
     runs-on: 'ubuntu-24.04'
     permissions:
-      contents: write
+      contents: write  # Upload assets to the draft GitHub release
     timeout-minutes: 5
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -1299,7 +1323,7 @@ jobs:
       - release-attach
     runs-on: 'ubuntu-24.04'
     permissions:
-      contents: write
+      contents: write  # Promote the draft GitHub release
     timeout-minutes: 5
     steps:
       # Load the egress allow-list out-of-band from the
@@ -1322,6 +1346,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Decide whether release is pre-release'
         id: release-kind
@@ -1389,6 +1415,7 @@ jobs:
           R_SIGN: ${{ needs.sign-attest.result }}
           R_ATTACH: ${{ needs.release-attach.result }}
           R_PROMOTE: ${{ needs.promote-release.result }}
+          REPO: ${{ github.repository }}
         run: |
           {
               echo "# Release ${TAG}"
@@ -1411,10 +1438,9 @@ jobs:
                   echo "Pull with:"
                   echo ""
                   echo "\`\`\`"
-                  repo="${{ github.repository }}"
-                  echo "docker pull ghcr.io/${repo}/client:${TAG}"
-                  echo "docker pull ghcr.io/${repo}/server:${TAG}"
-                  echo "docker pull ghcr.io/${repo}/bridge:${TAG}"
+                  echo "docker pull ghcr.io/${REPO}/client:${TAG}"
+                  echo "docker pull ghcr.io/${REPO}/server:${TAG}"
+                  echo "docker pull ghcr.io/${REPO}/bridge:${TAG}"
                   echo "\`\`\`"
               else
                   echo "## ❌ Release did not complete"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -351,14 +351,16 @@ jobs:
 
       - name: 'Load images into local Docker daemon'
         shell: bash
+        env:
+          PLATFORM_ID: ${{ steps.platform.outputs.id }}
         run: |
           set -euo pipefail
           for component in client server bridge; do
-              tarball="/tmp/${component}-${{ steps.platform.outputs.id }}.tar"
+              tarball="/tmp/${component}-${PLATFORM_ID}.tar"
               echo "Loading ${tarball}"
               docker load --input "${tarball}"
-              docker tag "${component}:${{ steps.platform.outputs.id }}" \
-                  "${component}-${{ steps.platform.outputs.id }}-image:test"
+              docker tag "${component}:${PLATFORM_ID}" \
+                  "${component}-${PLATFORM_ID}-image:test"
           done
           docker images | grep -E '(client|server|bridge)-' || true
 

--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -49,11 +49,20 @@ RUN dnf update -y && \
 # globs intentionally trail with '*' (not '.*'): idna 3.11 ships its
 # metadata as 'idna-3.11.dist-info' with no patch component, so
 # '*.dist-info' would miss it.
+# python3-cryptography 48.0.0 is likewise flagged by
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL bundled in the upstream
+# cryptography 48.0.0 wheels; fixed in 48.0.1), so upgrade it the
+# same way. The '<49' cap keeps the wheel on the same major series
+# as the Fedora package sigul builds against. cryptography is an
+# arch-specific package whose dnf metadata lives under /usr/lib64,
+# so that tree joins the dist-info cleanup below.
 RUN python3 -m pip install --upgrade --break-system-packages \
-        'pip>=26.1' 'idna>=3.15' && \
+        'pip>=26.1' 'idna>=3.15' 'cryptography>=48.0.1,<49' && \
     find /usr/lib/python3*/site-packages \
+        /usr/lib64/python3*/site-packages \
         \( -name 'pip-26.0*.dist-info' \
-        -o -name 'idna-3.11*.dist-info' \) \
+        -o -name 'idna-3.11*.dist-info' \
+        -o -name 'cryptography-48.0.0*.dist-info' \) \
         -type d -exec rm -rf {} +
 
 # Install EPEL-dependent packages and Python packages via pip

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -51,11 +51,20 @@ RUN dnf install -y --setopt=install_weak_deps=False --allowerasing \
 # globs intentionally trail with '*' (not '.*'): idna 3.11 ships its
 # metadata as 'idna-3.11.dist-info' with no patch component, so
 # '*.dist-info' would miss it.
+# python3-cryptography 48.0.0 is likewise flagged by
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL bundled in the upstream
+# cryptography 48.0.0 wheels; fixed in 48.0.1), so upgrade it the
+# same way. The '<49' cap keeps the wheel on the same major series
+# as the Fedora package sigul builds against. cryptography is an
+# arch-specific package whose dnf metadata lives under /usr/lib64,
+# so that tree joins the dist-info cleanup below.
 RUN python3 -m pip install --upgrade --break-system-packages \
-        'pip>=26.1' 'idna>=3.15' && \
+        'pip>=26.1' 'idna>=3.15' 'cryptography>=48.0.1,<49' && \
     find /usr/lib/python3*/site-packages \
+        /usr/lib64/python3*/site-packages \
         \( -name 'pip-26.0*.dist-info' \
-        -o -name 'idna-3.11*.dist-info' \) \
+        -o -name 'idna-3.11*.dist-info' \
+        -o -name 'cryptography-48.0.0*.dist-info' \) \
         -type d -exec rm -rf {} +
 
 # Copy patches for debugging (if they exist)

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -49,11 +49,20 @@ RUN dnf update -y && \
 # globs intentionally trail with '*' (not '.*'): idna 3.11 ships its
 # metadata as 'idna-3.11.dist-info' with no patch component, so
 # '*.dist-info' would miss it.
+# python3-cryptography 48.0.0 is likewise flagged by
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL bundled in the upstream
+# cryptography 48.0.0 wheels; fixed in 48.0.1), so upgrade it the
+# same way. The '<49' cap keeps the wheel on the same major series
+# as the Fedora package sigul builds against. cryptography is an
+# arch-specific package whose dnf metadata lives under /usr/lib64,
+# so that tree joins the dist-info cleanup below.
 RUN python3 -m pip install --upgrade --break-system-packages \
-        'pip>=26.1' 'idna>=3.15' && \
+        'pip>=26.1' 'idna>=3.15' 'cryptography>=48.0.1,<49' && \
     find /usr/lib/python3*/site-packages \
+        /usr/lib64/python3*/site-packages \
         \( -name 'pip-26.0*.dist-info' \
-        -o -name 'idna-3.11*.dist-info' \) \
+        -o -name 'idna-3.11*.dist-info' \
+        -o -name 'cryptography-48.0.0*.dist-info' \) \
         -type d -exec rm -rf {} +
 
 # Install EPEL-dependent packages and Python packages via pip


### PR DESCRIPTION
# Fix: resolve zizmor auditor persona findings

Bulk remediation of all **60 findings** reported by
[zizmor](https://docs.zizmor.sh/) when run with
`--persona auditor --min-severity low --no-online-audits`, plus a
container image CVE patch required to get this PR through its own
merge gates (see "Scope of this PR" below).

## Scope of this PR (three commits)

| Commit | Scope |
| ------ | ----- |
| `fd72e48` | Zizmor remediation across all workflows (the bulk of this PR, detailed below) |
| `f81f37b` | Container image CVE patch: pin `cryptography>=48.0.1,<49` in all three Dockerfiles (client/server/bridge) to remediate [GHSA-537c-gmf6-5ccf](https://github.com/advisories/GHSA-537c-gmf6-5ccf), and adjust the corresponding dist-info cleanup paths |
| `824190b` | Review follow-up: hoist remaining in-`run:` expression expansions into step `env:` (build-test.yaml, release.yaml) |

**Why the CVE patch rides along:** the vulnerability is pre-existing
on `main`, and this repository's required Grype scan gate fails any
PR whose image build carries it — including this one. The patch was
originally raised standalone as #138, but that PR could not merge
ahead of this one for the same reason, so it was cherry-picked here
and #138 closed as superseded. Without it, this PR cannot merge.

## Summary of zizmor fixes

| Audit | Count | Remediation |
| ----- | ----- | ----------- |
| template-injection | 36 | Hoisted every `${{ ... }}` expression used inside `run:` blocks into step-level `env:` variables, referenced as quoted shell variables |
| undocumented-permissions | 12 | Added trailing explanatory comments to every non-default permission scope |
| artipacked | 10 | Added `persist-credentials: false` to all `actions/checkout` steps |
| unsound-ternary | 2 | Removed no-op pseudo-ternaries in `platforms:` inputs (see below) |

## Method

- `build-test.yaml` and `release.yaml` (repo-specific docker build /
  release signing pipelines) were fixed surgically, preserving
  behaviour exactly: matrix values, `needs.*.result` values and
  `github.repository` are now passed to shell via `env:` instead of
  template expansion.
- **Ternary restructuring**: both docker build steps used
  `platforms: ${{ matrix.runner == 'ubuntu-24.04-arm' && '' || matrix.platform }}`.
  The truthy arm (`''`) is falsy, so the expression always evaluated
  to `matrix.platform` on both arms. It now references
  `${{ matrix.platform }}` directly — identical behaviour, with an
  explanatory comment left in place.
- No checkout in this repository pushes commits/tags with checkout
  credentials (release promotion and asset upload use `GITHUB_TOKEN`
  via `gh` / action inputs), so no `artipacked` exemptions were
  required.
- Boilerplate workflows (`release-drafter.yaml`,
  `openssf-scorecard.yaml`, `clear-action-cache.yaml`) were refreshed
  wholesale from the current org templates — they contained only
  stale-template drift and no local customisation. This bumps the
  reusable OpenSSF Scorecard workflow pin to `v0.7.2`.
- No action pins were downgraded; all pins remain full commit SHAs
  with version comments.

## Verification

```text
zizmor --persona auditor --min-severity low --no-online-audits .
No findings to report. Good job! (12 ignored)
```

yamllint passes (only pre-existing, non-fatal `comments-indentation`
warnings remain, unchanged from `main`). All required checks
(including the Grype image scan and Zizmor scan) pass on the current
head.
