### PR TITLE
Fix: patch cryptography CVE in container images

### DIFF
--- a/Dockerfile.bridge
+++ b/Dockerfile.bridge
@@ -49,11 +49,20 @@ RUN dnf update -y && \
 # globs intentionally trail with '*' (not '.*'): idna 3.11 ships its
 # metadata as 'idna-3.11.dist-info' with no patch component, so
 # '*.dist-info' would miss it.
+# python3-cryptography 48.0.0 is likewise flagged by
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL bundled in the upstream
+# cryptography 48.0.0 wheels; fixed in 48.0.1), so upgrade it the
+# same way. The '<49' cap keeps the wheel on the same major series
+# as the Fedora package sigul builds against. cryptography is an
+# arch-specific package whose dnf metadata lives under /usr/lib64,
+# so that tree joins the dist-info cleanup below.
 RUN python3 -m pip install --upgrade --break-system-packages \
-        'pip>=26.1' 'idna>=3.15' && \
+        'pip>=26.1' 'idna>=3.15' 'cryptography>=48.0.1,<49' && \
     find /usr/lib/python3*/site-packages \
+        /usr/lib64/python3*/site-packages \
         \( -name 'pip-26.0*.dist-info' \
-        -o -name 'idna-3.11*.dist-info' \) \
+        -o -name 'idna-3.11*.dist-info' \
+        -o -name 'cryptography-48.0.0*.dist-info' \) \
         -type d -exec rm -rf {} +
 
 # Install EPEL-dependent packages and Python packages via pip

--- a/Dockerfile.client
+++ b/Dockerfile.client
@@ -51,11 +51,20 @@ RUN dnf install -y --setopt=install_weak_deps=False --allowerasing \
 # globs intentionally trail with '*' (not '.*'): idna 3.11 ships its
 # metadata as 'idna-3.11.dist-info' with no patch component, so
 # '*.dist-info' would miss it.
+# python3-cryptography 48.0.0 is likewise flagged by
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL bundled in the upstream
+# cryptography 48.0.0 wheels; fixed in 48.0.1), so upgrade it the
+# same way. The '<49' cap keeps the wheel on the same major series
+# as the Fedora package sigul builds against. cryptography is an
+# arch-specific package whose dnf metadata lives under /usr/lib64,
+# so that tree joins the dist-info cleanup below.
 RUN python3 -m pip install --upgrade --break-system-packages \
-        'pip>=26.1' 'idna>=3.15' && \
+        'pip>=26.1' 'idna>=3.15' 'cryptography>=48.0.1,<49' && \
     find /usr/lib/python3*/site-packages \
+        /usr/lib64/python3*/site-packages \
         \( -name 'pip-26.0*.dist-info' \
-        -o -name 'idna-3.11*.dist-info' \) \
+        -o -name 'idna-3.11*.dist-info' \
+        -o -name 'cryptography-48.0.0*.dist-info' \) \
         -type d -exec rm -rf {} +
 
 # Copy patches for debugging (if they exist)

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -49,11 +49,20 @@ RUN dnf update -y && \
 # globs intentionally trail with '*' (not '.*'): idna 3.11 ships its
 # metadata as 'idna-3.11.dist-info' with no patch component, so
 # '*.dist-info' would miss it.
+# python3-cryptography 48.0.0 is likewise flagged by
+# GHSA-537c-gmf6-5ccf (vulnerable OpenSSL bundled in the upstream
+# cryptography 48.0.0 wheels; fixed in 48.0.1), so upgrade it the
+# same way. The '<49' cap keeps the wheel on the same major series
+# as the Fedora package sigul builds against. cryptography is an
+# arch-specific package whose dnf metadata lives under /usr/lib64,
+# so that tree joins the dist-info cleanup below.
 RUN python3 -m pip install --upgrade --break-system-packages \
-        'pip>=26.1' 'idna>=3.15' && \
+        'pip>=26.1' 'idna>=3.15' 'cryptography>=48.0.1,<49' && \
     find /usr/lib/python3*/site-packages \
+        /usr/lib64/python3*/site-packages \
         \( -name 'pip-26.0*.dist-info' \
-        -o -name 'idna-3.11*.dist-info' \) \
+        -o -name 'idna-3.11*.dist-info' \
+        -o -name 'cryptography-48.0.0*.dist-info' \) \
         -type d -exec rm -rf {} +
 
 # Install EPEL-dependent packages and Python packages via pip


### PR DESCRIPTION
# Fix: patch cryptography CVE in container images

## Summary

All three Grype release-gate jobs (client, server, bridge) currently
fail on **GHSA-537c-gmf6-5ccf**: the upstream `cryptography` 48.0.0
wheels bundle a vulnerable OpenSSL (High severity, fixed in
**48.0.1**). Fedora 44's `python3-cryptography` package ships the
affected version and no patched RPM is available yet, so the images
fail the `GRYPE_FAIL_ON: low` policy in `build-test.yaml` /
`release.yaml` (see the Grype failures on PR #137, which are
unrelated to that PR's workflow changes).

## Method

Extends the established in-image pip CVE-patch layer in
`Dockerfile.client`, `Dockerfile.server` and `Dockerfile.bridge`
(the same pattern already used to patch `pip` and `idna` that
Fedora 44 ships unpatched):

- `pip install --upgrade --break-system-packages
  'cryptography>=48.0.1,<49'` layered after the dnf install; the
  `<49` cap keeps the wheel on the same major series as the Fedora
  package sigul builds against.
- Removes the stale `cryptography-48.0.0*.dist-info` metadata so the
  Grype SBOM scan reports only the upgraded version. `cryptography`
  is an arch-specific package whose dnf-managed metadata lives under
  `/usr/lib64/python3*/site-packages`, so that tree is added to the
  existing dist-info cleanup roots.
- Comment referencing the advisory added alongside the existing
  pip/idna CVE notes.

No workflow changes; the `low` severity threshold on the Grype gate
is unchanged. Identical change applied to all three Dockerfiles.
