### PR TITLE
Fix: bump harden-runner allow-list to v0.5.1

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -62,7 +62,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -345,7 +345,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -461,7 +461,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -582,7 +582,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -1247,7 +1247,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/clear-action-cache.yaml
+++ b/.github/workflows/clear-action-cache.yaml
@@ -55,7 +55,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -30,7 +30,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -122,7 +122,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -493,7 +493,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -622,7 +622,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -808,7 +808,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -1013,7 +1013,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -1160,7 +1160,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'
@@ -1334,7 +1334,7 @@ jobs:
       # yamllint disable-line rule:line-length
       - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+          config: '@8f4f0cf83e6a015957e83261ed379fd811fc060e'  # v0.5.1
 
       # Harden the runner with the just-loaded allow-list.
       - name: 'Harden runner (block)'


### PR DESCRIPTION
## Summary

The `v0.1.4` tag push failed to promote the release
([run 29019961112](https://github.com/lfreleng-actions/sigul-sign-docker/actions/runs/29019961112)):
all three **Publish** jobs died at "Set up Docker Buildx" with

```text
ERROR: error pulling image configuration: download failed after
attempts=6: dial tcp 54.185.253.63:443: connect: connection refused
```

which cascaded to skip Sign+Attest and Promote Draft Release.

## Root cause

Every `harden-runner-block-action` step in this repository pinned the
organisation egress allow-list at **v0.1.1** (`@18d9c44`), which
predates Docker Hub's move to serving image blobs through CloudFront:

| Allow-list | Docker Hub endpoints |
| ---------- | -------------------- |
| v0.1.1 (pinned here) | `auth.docker.io`, `registry-1.docker.io`, `production.cloudflare.docker.com` |
| v0.5.1 (current) | the above **plus `production.cloudfront.docker.com:443`** |

`54.185.253.63` is an AWS CloudFront endpoint. Docker Hub serves
blobs through both Cloudflare and CloudFront, so pulls under the
stale list fail intermittently depending on which CDN answers.

The publish jobs became exposed when #137 switched them from
`egress-policy: audit` to `block` as part of the boilerplate
refresh (at v0.1.3 they ran audit mode and logged rather than
blocked). The heavier build jobs still run audit mode — with an
explanatory comment — and were unaffected, which is why everything
up to Publish succeeded in the failed run.

## Fix

Bump all **15** allow-list `config:` pins across the four workflows
(`release.yaml`, `build-test.yaml`, `clear-action-cache.yaml`,
`release-drafter.yaml`) from `@18d9c44` (v0.1.1) to `@8f4f0cf`
(v0.5.1). This matches the pin generation used by the organisation's
own central workflows.

## Verification

- `zizmor --persona auditor --min-severity low --no-online-audits .`
  — no findings
- prek hooks pass on all four changed workflows (yamllint,
  actionlint, gha-workflow-linter, reuse)

## After merge

Re-push the `v0.1.4` tag (or re-run the release workflow on it) to
complete the interrupted release promotion.
